### PR TITLE
Added no_std support

### DIFF
--- a/src/internal/convert.rs
+++ b/src/internal/convert.rs
@@ -1,7 +1,7 @@
-use std::convert::*;
+use core::convert::*;
 use super::pixel::*;
-use std::slice;
-use std::mem;
+use core::slice;
+use core::mem;
 use RGB;
 use RGBA;
 use alt::BGR;

--- a/src/internal/ops.rs
+++ b/src/internal/ops.rs
@@ -1,4 +1,4 @@
-use std::ops::*;
+use core::ops::*;
 use super::pixel::*;
 use RGB;
 use RGBA;

--- a/src/internal/pixel.rs
+++ b/src/internal/pixel.rs
@@ -1,4 +1,4 @@
-use std;
+use core;
 
 /// Casting the struct to slices of its components
 pub trait ComponentSlice<T> {
@@ -16,7 +16,7 @@ pub trait ComponentBytes<T: Copy + Send + Sync + 'static> where Self: ComponentS
     fn as_bytes(&self) -> &[u8] {
         let slice = self.as_slice();
         unsafe {
-            std::slice::from_raw_parts(slice.as_ptr() as *const _, slice.len() * std::mem::size_of::<T>())
+            core::slice::from_raw_parts(slice.as_ptr() as *const _, slice.len() * core::mem::size_of::<T>())
         }
     }
 
@@ -25,7 +25,7 @@ pub trait ComponentBytes<T: Copy + Send + Sync + 'static> where Self: ComponentS
     fn as_bytes_mut(&mut self) -> &mut [u8] {
         let slice = self.as_mut_slice();
         unsafe {
-            std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut _, slice.len() * std::mem::size_of::<T>())
+            core::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut _, slice.len() * core::mem::size_of::<T>())
         }
     }
 }

--- a/src/internal/rgb.rs
+++ b/src/internal/rgb.rs
@@ -1,5 +1,5 @@
-use std;
-use std::fmt;
+use core;
+use core::fmt;
 use super::pixel::*;
 use RGB;
 use RGBA;
@@ -17,7 +17,7 @@ macro_rules! impl_rgb {
 
             /// Iterate over color components (R, G, and B)
             #[inline(always)]
-            pub fn iter(&self) -> std::iter::Cloned<std::slice::Iter<T>> {
+            pub fn iter(&self) -> core::iter::Cloned<core::slice::Iter<T>> {
                 self.as_slice().iter().cloned()
             }
 
@@ -60,14 +60,14 @@ macro_rules! impl_rgb {
             #[inline(always)]
             fn as_slice(&self) -> &[T] {
                 unsafe {
-                    std::slice::from_raw_parts(self as *const Self as *const T, 3)
+                    core::slice::from_raw_parts(self as *const Self as *const T, 3)
                 }
             }
 
             #[inline(always)]
             fn as_mut_slice(&mut self) -> &mut [T] {
                 unsafe {
-                    std::slice::from_raw_parts_mut(self as *mut Self as *mut T, 3)
+                    core::slice::from_raw_parts_mut(self as *mut Self as *mut T, 3)
                 }
             }
         }
@@ -76,14 +76,14 @@ macro_rules! impl_rgb {
             #[inline]
             fn as_slice(&self) -> &[T] {
                 unsafe {
-                    std::slice::from_raw_parts(self.as_ptr() as *const _, self.len() * 3)
+                    core::slice::from_raw_parts(self.as_ptr() as *const _, self.len() * 3)
                 }
             }
 
             #[inline]
             fn as_mut_slice(&mut self) -> &mut [T] {
                 unsafe {
-                    std::slice::from_raw_parts_mut(self.as_ptr() as *mut _, self.len() * 3)
+                    core::slice::from_raw_parts_mut(self.as_ptr() as *mut _, self.len() * 3)
                 }
             }
         }
@@ -92,7 +92,7 @@ macro_rules! impl_rgb {
     }
 }
 
-impl<T> std::iter::FromIterator<T> for RGB<T> {
+impl<T> core::iter::FromIterator<T> for RGB<T> {
     /// Takes exactly 3 elements from the iterator and creates a new instance.
     /// Panics if there are fewer elements in the iterator.
     #[inline(always)]
@@ -121,29 +121,34 @@ impl<T: fmt::Display> fmt::Display for BGR<T> {
     }
 }
 
-#[test]
-fn rgb_test() {
-    let neg = RGB::new(1,2,3i32).map(|x| -x);
-    assert_eq!(neg.r, -1);
-    assert_eq!(neg.g, -2);
-    assert_eq!(neg.b, -3);
+#[cfg(test)]
+mod rgb_test {
+    use super::*;
+    use std;
+    #[test]
+    fn sanity_check() {
+        let neg = RGB::new(1,2,3i32).map(|x| -x);
+        assert_eq!(neg.r, -1);
+        assert_eq!(neg.g, -2);
+        assert_eq!(neg.b, -3);
 
-    let mut px = RGB::new(3,4,5);
-    px.as_mut_slice()[1] = 111;
-    assert_eq!(111, px.g);
+        let mut px = RGB::new(3,4,5);
+        px.as_mut_slice()[1] = 111;
+        assert_eq!(111, px.g);
 
-    assert_eq!(RGBA::new(250,251,252,253), RGB::new(250,251,252).alpha(253));
+        assert_eq!(RGBA::new(250,251,252,253), RGB::new(250,251,252).alpha(253));
 
-    assert_eq!(RGB{r:1u8,g:2,b:3}, RGB::new(1u8,2,3));
-    assert!(RGB{r:1u8,g:1,b:2} < RGB::new(2,1,1));
+        assert_eq!(RGB{r:1u8,g:2,b:3}, RGB::new(1u8,2,3));
+        assert!(RGB{r:1u8,g:1,b:2} < RGB::new(2,1,1));
 
-    let mut h = std::collections::HashSet::new();
-    h.insert(px);
-    assert!(h.contains(&RGB::new(3,111,5)));
-    assert!(!h.contains(&RGB::new(111,5,3)));
+        let mut h = std::collections::HashSet::new();
+        h.insert(px);
+        assert!(h.contains(&RGB::new(3,111,5)));
+        assert!(!h.contains(&RGB::new(111,5,3)));
 
-    let v = vec![RGB::new(1u8,2,3), RGB::new(4,5,6)];
-    assert_eq!(&[1,2,3,4,5,6], v.as_bytes());
+        let v = vec![RGB::new(1u8,2,3), RGB::new(4,5,6)];
+        assert_eq!(&[1,2,3,4,5,6], v.as_bytes());
 
-    assert_eq!(RGB::new(0u8,0,0), Default::default());
+        assert_eq!(RGB::new(0u8,0,0), Default::default());
+    }
 }

--- a/src/internal/rgba.rs
+++ b/src/internal/rgba.rs
@@ -1,5 +1,5 @@
-use std;
-use std::fmt;
+use core;
+use core::fmt;
 use super::pixel::*;
 use RGB;
 use RGBA;
@@ -18,7 +18,7 @@ macro_rules! impl_rgba {
         impl<T: Clone> $RGBA<T> {
             /// Iterate over all components (length=4)
             #[inline(always)]
-            pub fn iter(&self) -> std::iter::Cloned<std::slice::Iter<T>> {
+            pub fn iter(&self) -> core::iter::Cloned<core::slice::Iter<T>> {
                 self.as_slice().iter().cloned()
             }
         }
@@ -36,7 +36,7 @@ macro_rules! impl_rgba {
             #[inline(always)]
             pub fn rgb_mut(&mut self) -> &mut $RGB<T> {
                 unsafe {
-                    std::mem::transmute(self)
+                    core::mem::transmute(self)
                 }
             }
         }
@@ -69,14 +69,14 @@ macro_rules! impl_rgba {
             #[inline(always)]
             fn as_slice(&self) -> &[T] {
                 unsafe {
-                    std::slice::from_raw_parts(self as *const Self as *const T, 4)
+                    core::slice::from_raw_parts(self as *const Self as *const T, 4)
                 }
             }
 
             #[inline(always)]
             fn as_mut_slice(&mut self) -> &mut [T] {
                 unsafe {
-                    std::slice::from_raw_parts_mut(self as *mut Self as *mut T, 4)
+                    core::slice::from_raw_parts_mut(self as *mut Self as *mut T, 4)
                 }
             }
         }
@@ -85,13 +85,13 @@ macro_rules! impl_rgba {
             #[inline]
             fn as_slice(&self) -> &[T] {
                 unsafe {
-                    std::slice::from_raw_parts(self.as_ptr() as *const _, self.len() * 4)
+                    core::slice::from_raw_parts(self.as_ptr() as *const _, self.len() * 4)
                 }
             }
             #[inline]
             fn as_mut_slice(&mut self) -> &mut [T] {
                 unsafe {
-                    std::slice::from_raw_parts_mut(self.as_ptr() as *mut _, self.len() * 4)
+                    core::slice::from_raw_parts_mut(self.as_ptr() as *mut _, self.len() * 4)
                 }
             }
         }
@@ -124,7 +124,7 @@ macro_rules! impl_rgba {
     }
 }
 
-impl<T> std::iter::FromIterator<T> for RGBA<T> {
+impl<T> core::iter::FromIterator<T> for RGBA<T> {
     #[inline(always)]
     /// Takes exactly 4 elements from the iterator and creates a new instance.
     /// Panics if there are fewer elements in the iterator.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,12 @@
 //! ```
 #![doc(html_logo_url = "https://kornel.ski/rgb-logo.png")]
 
+#![no_std]
+
+// std is required to run unit tests
+#[cfg(test)]
+#[macro_use] extern crate std;
+
 #[cfg(feature = "serde")]
 #[macro_use] extern crate serde;
 


### PR DESCRIPTION
This crate would be great for my use case, except that it is ``#[no_std]``. Given its simplicity, I was surprised that ``#[no_std]`` wasn't already supported, so I tried to add it... and it was amazingly easy.

Perhaps too easy. I am still learning the details of ``#[no_std]`` crates, so any feedback is welcome.