### PR TITLE
Implement conversions to/from fixed-size arrays

### DIFF
--- a/src/internal/convert/array.rs
+++ b/src/internal/convert/array.rs
@@ -1,0 +1,91 @@
+use alt::{BGR, BGRA};
+use {RGB, RGBA};
+
+impl<T: Copy> From<[T; 3]> for RGB<T> {
+    #[inline]
+    fn from(other: [T; 3]) -> Self {
+        Self {
+            r: other[0],
+            g: other[1],
+            b: other[2],
+        }
+    }
+}
+
+impl<T> Into<[T; 3]> for RGB<T> {
+    #[inline]
+    fn into(self) -> [T; 3] {
+        [self.r, self.g, self.b]
+    }
+}
+
+impl<T: Copy> From<[T; 4]> for RGBA<T> {
+    #[inline]
+    fn from(other: [T; 4]) -> Self {
+        Self {
+            r: other[0],
+            g: other[1],
+            b: other[2],
+            a: other[3],
+        }
+    }
+}
+
+impl<T> Into<[T; 4]> for RGBA<T> {
+    #[inline]
+    fn into(self) -> [T; 4] {
+        [self.r, self.g, self.b, self.a]
+    }
+}
+
+impl<T: Copy> From<[T; 3]> for BGR<T> {
+    #[inline]
+    fn from(other: [T; 3]) -> Self {
+        Self {
+            b: other[0],
+            g: other[1],
+            r: other[2],
+        }
+    }
+}
+
+impl<T> Into<[T; 3]> for BGR<T> {
+    #[inline]
+    fn into(self) -> [T; 3] {
+        [self.b, self.g, self.r]
+    }
+}
+
+impl<T: Copy> From<[T; 4]> for BGRA<T> {
+    #[inline]
+    fn from(other: [T; 4]) -> Self {
+        Self {
+            b: other[0],
+            g: other[1],
+            r: other[2],
+            a: other[3],
+        }
+    }
+}
+
+impl<T> Into<[T; 4]> for BGRA<T> {
+    #[inline]
+    fn into(self) -> [T; 4] {
+        [self.b, self.g, self.r, self.a]
+    }
+}
+
+#[test]
+fn convert_array() {
+    use alt::{BGR8, BGRA8};
+    use {RGB8, RGBA8};
+
+    assert!(RGB8::from([1, 2, 3]) == RGB8::new(1, 2, 3));
+    assert!(Into::<[u8; 3]>::into(RGB8::new(1, 2, 3)) == [1, 2, 3]);
+    assert!(RGBA8::from([1, 2, 3, 4]) == RGBA8::new(1, 2, 3, 4));
+    assert!(Into::<[u8; 4]>::into(RGBA8::new(1, 2, 3, 4)) == [1, 2, 3, 4]);
+    assert!(BGR8::from([3, 2, 1]) == BGR8::new(1, 2, 3));
+    assert!(Into::<[u8; 3]>::into(BGR8::new(1, 2, 3)) == [3, 2, 1]);
+    assert!(BGRA8::from([3, 2, 1, 4]) == BGRA8 { r: 1, g: 2, b: 3, a: 4 });
+    assert!(Into::<[u8; 4]>::into(BGRA8 { r: 1, g: 2, b: 3, a: 4 }) == [3, 2, 1, 4]);
+}

--- a/src/internal/convert/mod.rs
+++ b/src/internal/convert/mod.rs
@@ -9,6 +9,7 @@ use alt::BGRA;
 use alt::Gray;
 use alt::GrayAlpha;
 
+mod array;
 mod tuple;
 
 /// Cast a slice of component values (bytes) as a slice of RGB/RGBA pixels


### PR DESCRIPTION
This seemed like a useful idea for interop with some other crates (i.e. `gltf`). Note the `Copy` trait bound on the `From` `impl`s; I could work around that requirement with some `unsafe` code, but it seems potentially cleaner to wait for NLL to land since it will supposedly provide a safe way to destructure the array.