### PR TITLE
Remove explicit clone in favor of copy

### DIFF
--- a/src/alt.rs
+++ b/src/alt.rs
@@ -126,11 +126,11 @@ impl<T: Copy> From<T> for Gray<T> {
     }
 }
 
-impl<T: Clone, A> GrayAlpha<T, A> {
+impl<T: Copy, A> GrayAlpha<T, A> {
     /// Copy `Gray` component out of the `GrayAlpha` struct
     #[inline(always)]
     pub fn gray(&self) -> Gray<T> {
-        Gray(self.0.clone())
+        Gray(self.0)
     }
 }
 
@@ -144,7 +144,7 @@ impl<T, A> GrayAlpha<T, A> {
     }
 }
 
-impl<T: Copy, A: Clone> GrayAlpha<T, A> {
+impl<T: Copy, A: Copy> GrayAlpha<T, A> {
     #[inline(always)]
     /// Create a new `GrayAlpha` with the new alpha value, but same gray value
     pub fn alpha(&self, a: A) -> Self {
@@ -155,14 +155,14 @@ impl<T: Copy, A: Clone> GrayAlpha<T, A> {
     pub fn map_alpha<F, B>(&self, f: F) -> GrayAlpha<T, B>
         where F: FnOnce(A) -> B
     {
-        GrayAlpha (self.0, f(self.1.clone()))
+        GrayAlpha (self.0, f(self.1))
     }
 
     /// Create new `GrayAlpha` with the same alpha value, but different `Gray` value
     #[inline(always)]
     pub fn map_gray<F, U, B>(&self, f: F) -> GrayAlpha<U, B>
         where F: FnOnce(T) -> U, U: Clone, B: From<A> + Clone {
-        GrayAlpha(f(self.0.clone()), self.1.clone().into())
+        GrayAlpha(f(self.0), self.1.into())
     }
 }
 

--- a/src/internal/convert/mod.rs
+++ b/src/internal/convert/mod.rs
@@ -175,21 +175,21 @@ rgb_impl_from!{RGBA, i16,f64}
 rgb_impl_from!{RGBA, i32,f64}
 rgb_impl_from!{RGBA, f32,f64}
 
-impl<T: Clone> From<Gray<T>> for RGB<T> {
+impl<T: Copy> From<Gray<T>> for RGB<T> {
     fn from(other: Gray<T>) -> Self {
         Self {
-            r: other.0.clone(),
-            g: other.0.clone(),
+            r: other.0,
+            g: other.0,
             b: other.0,
         }
     }
 }
 
-impl<T: Clone,A> From<GrayAlpha<T,A>> for RGBA<T,A> {
+impl<T: Copy,A> From<GrayAlpha<T,A>> for RGBA<T,A> {
     fn from(other: GrayAlpha<T,A>) -> Self {
         Self {
-            r: other.0.clone(),
-            g: other.0.clone(),
+            r: other.0,
+            g: other.0,
             b: other.0,
             a: other.1,
         }

--- a/src/internal/ops.rs
+++ b/src/internal/ops.rs
@@ -288,7 +288,7 @@ mod test {
     #[should_panic]
     #[cfg(debug_assertions)]
     fn test_add_overflow() {
-        assert_ne!(RGBA::new(255u8, 255, 0, 0), RED_RGBA+BLUE_RGBA);;
+        assert_ne!(RGBA::new(255u8, 255, 0, 0), RED_RGBA+BLUE_RGBA);
     }
 
     #[test]

--- a/src/internal/rgb.rs
+++ b/src/internal/rgb.rs
@@ -16,7 +16,7 @@ macro_rules! impl_rgb {
                 Self { r, g, b }
             }
         }
-        impl<T: Clone> $RGB<T> {
+        impl<T: Copy> $RGB<T> {
             /// Iterate over color components (R, G, and B)
             #[inline(always)]
             pub fn iter(&self) -> core::iter::Cloned<core::slice::Iter<'_, T>> {
@@ -27,9 +27,9 @@ macro_rules! impl_rgb {
             #[inline(always)]
             pub fn alpha(&self, a: T) -> $RGBA<T> {
                 $RGBA {
-                    r: self.r.clone(),
-                    g: self.g.clone(),
-                    b: self.b.clone(),
+                    r: self.r,
+                    g: self.g,
+                    b: self.b,
                     a,
                 }
             }
@@ -38,9 +38,9 @@ macro_rules! impl_rgb {
             #[inline(always)]
             pub fn new_alpha<A>(&self, a: A) -> $RGBA<T, A> {
                 $RGBA {
-                    r: self.r.clone(),
-                    g: self.g.clone(),
-                    b: self.b.clone(),
+                    r: self.r,
+                    g: self.g,
+                    b: self.b,
                     a,
                 }
             }

--- a/src/internal/rgba.rs
+++ b/src/internal/rgba.rs
@@ -33,17 +33,17 @@ macro_rules! impl_rgba {
             }
         }
 
-        impl<T: Clone, A> $RGBA<T, A> {
+        impl<T: Copy, A> $RGBA<T, A> {
             /// Copy RGB components out of the RGBA struct
             ///
             /// Note: you can use `.into()` to convert between other types
             #[inline(always)]
             pub fn bgr(&self) -> BGR<T> {
-                BGR {r:self.r.clone(), g:self.g.clone(), b:self.b.clone()}
+                BGR {r:self.r, g:self.g, b:self.b}
             }
         }
 
-        impl<T: Copy, A: Clone> $RGBA<T, A> {
+        impl<T: Copy, A: Copy> $RGBA<T, A> {
             /// Create new RGBA with the same alpha value, but different RGB values
             #[inline(always)]
             pub fn map_rgb<F, U, B>(&self, mut f: F) -> $RGBA<U, B>
@@ -53,7 +53,7 @@ macro_rules! impl_rgba {
                     r: f(self.r),
                     g: f(self.g),
                     b: f(self.b),
-                    a: self.a.clone().into(),
+                    a: self.a.into(),
                 }
             }
 
@@ -73,7 +73,7 @@ macro_rules! impl_rgba {
                     r: self.r,
                     g: self.g,
                     b: self.b,
-                    a: f(self.a.clone()),
+                    a: f(self.a),
                 }
             }
         }
@@ -202,24 +202,24 @@ impl<T> core::iter::FromIterator<T> for RGBA<T> {
     }
 }
 
-impl<T: Clone, A> RGBA<T, A> {
+impl<T: Copy, A> RGBA<T, A> {
     /// Copy RGB components out of the RGBA struct
     ///
     /// Note: you can use `.into()` to convert between other types
     #[inline(always)]
     pub fn rgb(&self) -> RGB<T> {
-        RGB {r:self.r.clone(), g:self.g.clone(), b:self.b.clone()}
+        RGB {r:self.r, g:self.g, b:self.b}
     }
 }
 
-impl<T: Clone, A> BGRA<T, A> {
+impl<T: Copy, A> BGRA<T, A> {
     /// Copy RGB components out of the RGBA struct
     ///
     /// Note: you can use `.into()` to convert between other types
     #[inline(always)]
     #[deprecated(note = "This function will change. Use bgr()")]
     pub fn rgb(&self) -> BGR<T> {
-        BGR {r:self.r.clone(), g:self.g.clone(), b:self.b.clone()}
+        BGR {r:self.r, g:self.g, b:self.b}
     }
 }
 


### PR DESCRIPTION
Hello!

I'm having trouble seeing the reasoning behind explicitly `.clone()`ing everywhere, as I believe `.clone()` is a very expensive operation.

Please let me know if there's a reason that I'm just completely missing :)

In this pull request, I've gone ahead and removed all instances of `.clone()` that I saw as potentially superfluous.