### PR TITLE
Add Use Statements to Docstring Example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,10 @@
 //! let pixel = pixel_rgba.rgb();
 //!
 //! let pixels = vec![pixel; 100];
+//! use rgb::ComponentBytes; // Import byte conversion trait
 //! let bytes = pixels.as_bytes();
 //!
+//! use rgb::ComponentMap; // Import pixel map trait
 //! let half_bright = pixel.map(|channel| channel / 2);
 //! let doubled = half_bright * 2;
 //! # let _ = doubled;


### PR DESCRIPTION
Hey there, I found it a little confusing at first as I tried to figure out how to convert my pixels into bytes partly because I didn't realize I had to import the `ComponentBytes` trait. Hopefully this minor addition to the documentation will help others, too. :slightly_smiling_face: 