### PR TITLE
enable the use of Serde in no_std environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ argb = []
 travis-ci = { repository = "kornelski/rust-rgb" }
 
 [dependencies]
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 bytemuck = { version = "1.2.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Serde by [default](https://serde.rs/no-std.html) enables the `std` feature. Declaring `default-features = false` fixes this, enabling `no_std` usage.