### PR TITLE
Generalize `iter` on `RGB<T>` and `RGBA<T>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ fn rgba_works() {
 
 #[test]
 fn bytes() {
-    let rgb = RGB8::new(1,2,3);
+    let mut rgb = RGB8::new(1,2,3);
 
     #[cfg(feature = "as-bytes")]
     {
@@ -191,9 +191,8 @@ fn bytes() {
         assert_eq!(&[rgb], rgb_bytes.as_rgb());
         assert_eq!(&[rgb], rgb_bytes.as_pixels());
     }
-    let mut rgb2 = [rgb];
-    assert_eq!(rgb2.as_mut_slice().as_rgb_mut(), &mut [rgb]);
-    assert_eq!(&mut [rgb], rgb2.as_mut_slice().as_pixels_mut());
+    assert_eq!(&mut [rgb], rgb.as_mut_slice().as_rgb_mut());
+    assert_eq!(&mut [rgb], rgb.as_mut_slice().as_pixels_mut());
 
 
     #[cfg(feature = "as-bytes")]
@@ -214,14 +213,13 @@ fn bytes() {
     assert_eq!(&[rgb], rgb_slice.as_rgb());
     assert_eq!(rgb, rgb_slice.into_iter().cloned().collect());
 
-    let rgba = RGBA16::new(1,2,3,4);
+    let mut rgba = RGBA16::new(1,2,3,4);
     let rgba_slice = rgba.as_slice();
     assert_eq!(&[1,2,3,4], rgba_slice);
     assert_eq!(&[1,2,3], rgba_slice.as_rgb()[0].as_slice());
     assert_eq!(&[rgba], rgba_slice.as_rgba());
     assert_eq!(rgba, rgba_slice.into_iter().cloned().collect());
-    let mut rgba2 = [rgba];
-    assert_eq!(rgba2.as_mut_slice().as_rgba_mut(), &mut [rgba]);
+    assert_eq!(&mut [rgba], rgba.as_mut_slice().as_rgba_mut());
 
     let mut foo = vec![0u8; 8];
     foo.as_rgba_mut()[1] = RGBA::new(1,2,3,4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ fn rgb_works() {
     let rgb = RGB{r:0u8,g:128,b:255}.clone();
     assert_eq!(rgb.b, 255);
 
-    assert_eq!(rgb, rgb.iter().map(|ch| ch).collect());
+    assert_eq!(rgb, rgb.iter().copied().collect());
 
     #[cfg(feature = "as-bytes")]
     {
@@ -169,7 +169,7 @@ fn rgba_works() {
     assert_eq!(rgba.b, 255);
     assert_eq!(rgba.a, 33);
 
-    assert_eq!(rgba, rgba.iter().map(|ch| ch).collect());
+    assert_eq!(rgba, rgba.iter().copied().collect());
 
     assert_eq!("rgba(1,2,3,4)", format!("{}", RGBA::new(1,2,3,4)));
 


### PR DESCRIPTION
This PR rewrites the `iter` methods on `RGB<T>` and `RGBA<T>` to return a custom iterator over `&T`, rather than casting to a slice and then cloning each value. This is in line with the typical behavior of methods named `iter` e.g. in the standard library. In the common case where `T: Copy` you can adapt to this change just by inserting `.copied()`. As a result, these methods no longer require constraining `T`.

I also fixed the tests in `src/lib.rs`.

This is a breaking API change and could perhaps be folded into a 1.0 release.