### PR TITLE
Add Pixel Trait and first implementation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,6 @@ edition = "2021"
 [features]
 default = []
 
-argb = []
-grb = []
-bgr = []
-
 # Enable `checked_add` and `checked_sub` methods on `RGB<u8>`
 checked_fns = []
 

--- a/src/abgr.rs
+++ b/src/abgr.rs
@@ -1,3 +1,5 @@
+use crate::Pixel;
+
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
@@ -9,13 +11,46 @@
 ///
 /// You can specify a different type for alpha, but it's only for special cases
 /// (e.g. if you use a newtype like `Abgr<LinearLight<u16>, u16>`).
-pub struct Abgr<T, A = T> {
+pub struct Abgr<T> {
     /// Alpha Component
-    pub a: A,
+    pub a: T,
     /// Blue Component
     pub b: T,
     /// Green Component
     pub g: T,
     /// Red Component
     pub r: T,
+}
+
+impl<T> Pixel<T, 4> for Abgr<T> {
+    fn as_components(self) -> [T; 4] {
+        [self.a, self.b, self.g, self.r]
+    }
+
+    fn as_components_ref(&self) -> &[T; 4] {
+        unsafe { core::mem::transmute(self) }
+    }
+
+    fn as_components_mut(&mut self) -> &mut [T; 4] {
+        unsafe { core::mem::transmute(self) }
+    }
+
+    fn from_components(components: [T; 4]) -> Self {
+        let mut iter = components.into_iter();
+
+        Self {
+            a: iter.next().unwrap(),
+            b: iter.next().unwrap(),
+            g: iter.next().unwrap(),
+            r: iter.next().unwrap(),
+        }
+    }
+
+    fn from_components_ref(components: &[T; 4]) -> &Self {
+        unsafe { core::mem::transmute(components) }
+    }
+
+    fn from_components_mut(components: &mut [T; 4]) -> &mut Self {
+        unsafe { core::mem::transmute(components) }
+    }
 }

--- a/src/abgr.rs
+++ b/src/abgr.rs
@@ -1,5 +1,3 @@
-use crate::Pixel;
-
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
@@ -20,37 +18,4 @@ pub struct Abgr<T> {
     pub g: T,
     /// Red Component
     pub r: T,
-}
-
-impl<T> Pixel<T, 4> for Abgr<T> {
-    fn into_components(self) -> [T; 4] {
-        [self.a, self.b, self.g, self.r]
-    }
-
-    fn as_components_ref(&self) -> &[T; 4] {
-        unsafe { core::mem::transmute(self) }
-    }
-
-    fn as_components_mut(&mut self) -> &mut [T; 4] {
-        unsafe { core::mem::transmute(self) }
-    }
-
-    fn from_components(components: [T; 4]) -> Self {
-        let mut iter = components.into_iter();
-
-        Self {
-            a: iter.next().unwrap(),
-            b: iter.next().unwrap(),
-            g: iter.next().unwrap(),
-            r: iter.next().unwrap(),
-        }
-    }
-
-    fn from_components_ref(components: &[T; 4]) -> &Self {
-        unsafe { core::mem::transmute(components) }
-    }
-
-    fn from_components_mut(components: &mut [T; 4]) -> &mut Self {
-        unsafe { core::mem::transmute(components) }
-    }
 }

--- a/src/abgr.rs
+++ b/src/abgr.rs
@@ -23,7 +23,7 @@ pub struct Abgr<T> {
 }
 
 impl<T> Pixel<T, 4> for Abgr<T> {
-    fn as_components(self) -> [T; 4] {
+    fn into_components(self) -> [T; 4] {
         [self.a, self.b, self.g, self.r]
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,17 @@ mod gray_alpha;
 mod grb;
 mod rgb;
 mod rgba;
+
+mod pixel;
+
+pub use abgr::Abgr;
+pub use argb::Argb;
+pub use bgr::Bgr;
+pub use bgra::Bgra;
+pub use gray::Gray;
+pub use gray_alpha::GrayAlpha;
+pub use grb::Grb;
+pub use rgb::Rgb;
+pub use rgba::Rgba;
+
+pub use pixel::Pixel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,4 @@ pub use grb::Grb;
 pub use rgb::Rgb;
 pub use rgba::Rgba;
 
-pub use pixel::Pixel;
+pub use pixel::{Pixel, PixelExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,4 @@ pub use grb::Grb;
 pub use rgb::Rgb;
 pub use rgba::Rgba;
 
-pub use pixel::{Pixel, PixelExt};
+pub use pixel::{HeterogeneousPixel, HomogeneousPixel};

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,0 +1,19 @@
+/// A Pixel made up of a compile-time known number of contiguously stored `T`s.
+///
+/// Usually `T` is a small copiable intrinsic type such as `u8`, `u16` or `f32`.
+pub trait Pixel<T, const N: usize> {
+    /// Converts an owned `Pixel` type to an array of its components.
+    #[allow(clippy::wrong_self_convention)]
+    fn as_components(self) -> [T; N];
+    /// Converts a reference of a `Pixel` type to a reference of an array of its components.
+    fn as_components_ref(&self) -> &[T; N];
+    /// Converts a mutable reference of a `Pixel` type to a mutable reference of an array of its components.
+    fn as_components_mut(&mut self) -> &mut [T; N];
+
+    /// Converts an array of components to a `Pixel`.
+    fn from_components(components: [T; N]) -> Self;
+    /// Converts a reference of an array of components to a refrecce of a `Pixel`.
+    fn from_components_ref(components: &[T; N]) -> &Self;
+    /// Converts a mutable reference of an array of components to a mutable reference of a `Pixel`.
+    fn from_components_mut(components: &mut [T; N]) -> &mut Self;
+}

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -6,18 +6,9 @@ pub trait HomogeneousPixel<T, const N: usize> {
     type PixelWithComponent<U>;
 
     /// Converts an owned `Pixel` type to an array of its components.
-    fn into_components(self) -> [T; N];
-    /// Converts a reference of a `Pixel` type to a reference of an array of its components.
-    fn as_components_ref(&self) -> &[T; N];
-    /// Converts a mutable reference of a `Pixel` type to a mutable reference of an array of its components.
-    fn as_components_mut(&mut self) -> &mut [T; N];
-
+    fn components(&self) -> [T; N];
     /// Converts an array of components to a `Pixel`.
     fn from_components(components: [T; N]) -> Self;
-    /// Converts a reference of an array of components to a refrecce of a `Pixel`.
-    fn from_components_ref(components: &[T; N]) -> &Self;
-    /// Converts a mutable reference of an array of components to a mutable reference of a `Pixel`.
-    fn from_components_mut(components: &mut [T; N]) -> &mut Self;
 
     /// Map the pixel to the same outer pixel type with an optionally different inner type.
     fn map<U>(&self, f: impl FnMut(T) -> U) -> Self::PixelWithComponent<U>
@@ -25,7 +16,7 @@ pub trait HomogeneousPixel<T, const N: usize> {
         Self::PixelWithComponent<U>: HomogeneousPixel<U, N>,
         Self: Copy,
     {
-        Self::PixelWithComponent::from_components(self.into_components().map(f))
+        Self::PixelWithComponent::from_components(self.components().map(f))
     }
 }
 

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -16,3 +16,18 @@ pub trait Pixel<T, const N: usize> {
     /// Converts a mutable reference of an array of components to a mutable reference of a `Pixel`.
     fn from_components_mut(components: &mut [T; N]) -> &mut Self;
 }
+
+/// Pixel extension trait for helper functions
+pub trait PixelExt<T, const N: usize>: Pixel<T, N> {
+    /// The same pixel type as Self but with a different generic component type.
+    type PixelWithComponent<U>;
+
+    /// Map a Pixel<T> to a different Pixel<U>
+    fn map<U>(&self, f: impl FnMut(T) -> U) -> Self::PixelWithComponent<U>
+    where
+        Self::PixelWithComponent<U>: Pixel<U, N>,
+        Self: Copy,
+    {
+        Self::PixelWithComponent::from_components(self.into_components().map(f))
+    }
+}

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,7 +1,10 @@
 /// A Pixel made up of a compile-time known number of contiguously stored `T`s.
 ///
 /// Usually `T` is a small copiable intrinsic type such as `u8`, `u16` or `f32`.
-pub trait Pixel<T, const N: usize> {
+pub trait HomogeneousPixel<T, const N: usize> {
+    /// The same pixel type as Self but with a different generic component type.
+    type PixelWithComponent<U>;
+
     /// Converts an owned `Pixel` type to an array of its components.
     fn into_components(self) -> [T; N];
     /// Converts a reference of a `Pixel` type to a reference of an array of its components.
@@ -15,19 +18,45 @@ pub trait Pixel<T, const N: usize> {
     fn from_components_ref(components: &[T; N]) -> &Self;
     /// Converts a mutable reference of an array of components to a mutable reference of a `Pixel`.
     fn from_components_mut(components: &mut [T; N]) -> &mut Self;
-}
 
-/// Pixel extension trait for helper functions
-pub trait PixelExt<T, const N: usize>: Pixel<T, N> {
-    /// The same pixel type as Self but with a different generic component type.
-    type PixelWithComponent<U>;
-
-    /// Map a Pixel<T> to a different Pixel<U>
+    /// Map the pixel to the same outer pixel type with an optionally different inner type.
     fn map<U>(&self, f: impl FnMut(T) -> U) -> Self::PixelWithComponent<U>
     where
-        Self::PixelWithComponent<U>: Pixel<U, N>,
+        Self::PixelWithComponent<U>: HomogeneousPixel<U, N>,
         Self: Copy,
     {
         Self::PixelWithComponent::from_components(self.into_components().map(f))
+    }
+}
+
+/// A pixel with possibly differently typed color and alpha components.
+pub trait HeterogeneousPixel<T, A, const N: usize> {
+    /// The same pixel type as Self but with a different generic component types.
+    type PixelWithComponent<U, B>;
+
+    /// The color components
+    fn colors(&self) -> [T; N];
+    /// The alpha component
+    fn alpha(&self) -> A;
+
+    /// Create a new instance given the color and alpha components.
+    fn from_colors_alpha(colors: [T; N], alpha: A) -> Self;
+
+    /// Map the pixel to the same outer pixel type with an optionally different inner color component
+    /// type and the exact same alpha component.
+    fn map_colors<U>(&self, f: impl FnMut(T) -> U) -> Self::PixelWithComponent<U, A>
+    where
+        Self::PixelWithComponent<U, A>: HeterogeneousPixel<U, A, N>,
+    {
+        Self::PixelWithComponent::from_colors_alpha(self.colors().map(f), self.alpha())
+    }
+
+    /// Map the pixel to the same outer pixel type with an optionally different inner color component
+    /// type and the exact same alpha component.
+    fn map_alpha<B>(&self, mut f: impl FnMut(A) -> B) -> Self::PixelWithComponent<T, B>
+    where
+        Self::PixelWithComponent<T, B>: HeterogeneousPixel<T, B, N>,
+    {
+        Self::PixelWithComponent::from_colors_alpha(self.colors(), f(self.alpha()))
     }
 }

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -3,8 +3,7 @@
 /// Usually `T` is a small copiable intrinsic type such as `u8`, `u16` or `f32`.
 pub trait Pixel<T, const N: usize> {
     /// Converts an owned `Pixel` type to an array of its components.
-    #[allow(clippy::wrong_self_convention)]
-    fn as_components(self) -> [T; N];
+    fn into_components(self) -> [T; N];
     /// Converts a reference of a `Pixel` type to a reference of an array of its components.
     fn as_components_ref(&self) -> &[T; N];
     /// Converts a mutable reference of a `Pixel` type to a mutable reference of an array of its components.

--- a/src/rgba.rs
+++ b/src/rgba.rs
@@ -1,4 +1,4 @@
-use crate::{Pixel, PixelExt};
+use crate::{HeterogeneousPixel, HomogeneousPixel};
 
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -22,7 +22,9 @@ pub struct Rgba<T, A = T> {
     pub a: A,
 }
 
-impl<T> Pixel<T, 4> for Rgba<T> {
+impl<T> HomogeneousPixel<T, 4> for Rgba<T> {
+    type PixelWithComponent<U> = Rgba<U>;
+
     fn into_components(self) -> [T; 4] {
         [self.a, self.b, self.g, self.r]
     }
@@ -55,6 +57,27 @@ impl<T> Pixel<T, 4> for Rgba<T> {
     }
 }
 
-impl<T> PixelExt<T, 4> for Rgba<T> {
-    type PixelWithComponent<U> = Rgba<U>;
+impl<T, A> HeterogeneousPixel<T, A, 3> for Rgba<T, A>
+where
+    T: Copy,
+    A: Copy,
+{
+    type PixelWithComponent<U, B> = Rgba<U, B>;
+
+    fn colors(&self) -> [T; 3] {
+        [self.r, self.g, self.b]
+    }
+
+    fn alpha(&self) -> A {
+        self.a
+    }
+
+    fn from_colors_alpha(colors: [T; 3], alpha: A) -> Self {
+        Self {
+            r: colors[0],
+            g: colors[1],
+            b: colors[2],
+            a: alpha,
+        }
+    }
 }

--- a/src/rgba.rs
+++ b/src/rgba.rs
@@ -22,19 +22,14 @@ pub struct Rgba<T, A = T> {
     pub a: A,
 }
 
-impl<T> HomogeneousPixel<T, 4> for Rgba<T> {
+impl<T> HomogeneousPixel<T, 4> for Rgba<T>
+where
+    T: Copy,
+{
     type PixelWithComponent<U> = Rgba<U>;
 
-    fn into_components(self) -> [T; 4] {
+    fn components(&self) -> [T; 4] {
         [self.a, self.b, self.g, self.r]
-    }
-
-    fn as_components_ref(&self) -> &[T; 4] {
-        unsafe { core::mem::transmute(self) }
-    }
-
-    fn as_components_mut(&mut self) -> &mut [T; 4] {
-        unsafe { core::mem::transmute(self) }
     }
 
     fn from_components(components: [T; 4]) -> Self {
@@ -46,14 +41,6 @@ impl<T> HomogeneousPixel<T, 4> for Rgba<T> {
             g: iter.next().unwrap(),
             r: iter.next().unwrap(),
         }
-    }
-
-    fn from_components_ref(components: &[T; 4]) -> &Self {
-        unsafe { core::mem::transmute(components) }
-    }
-
-    fn from_components_mut(components: &mut [T; 4]) -> &mut Self {
-        unsafe { core::mem::transmute(components) }
     }
 }
 

--- a/src/rgba.rs
+++ b/src/rgba.rs
@@ -1,3 +1,5 @@
+use crate::{Pixel, PixelExt};
+
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
@@ -18,4 +20,41 @@ pub struct Rgba<T, A = T> {
     pub b: T,
     /// Alpha Component
     pub a: A,
+}
+
+impl<T> Pixel<T, 4> for Rgba<T> {
+    fn into_components(self) -> [T; 4] {
+        [self.a, self.b, self.g, self.r]
+    }
+
+    fn as_components_ref(&self) -> &[T; 4] {
+        unsafe { core::mem::transmute(self) }
+    }
+
+    fn as_components_mut(&mut self) -> &mut [T; 4] {
+        unsafe { core::mem::transmute(self) }
+    }
+
+    fn from_components(components: [T; 4]) -> Self {
+        let mut iter = components.into_iter();
+
+        Self {
+            a: iter.next().unwrap(),
+            b: iter.next().unwrap(),
+            g: iter.next().unwrap(),
+            r: iter.next().unwrap(),
+        }
+    }
+
+    fn from_components_ref(components: &[T; 4]) -> &Self {
+        unsafe { core::mem::transmute(components) }
+    }
+
+    fn from_components_mut(components: &mut [T; 4]) -> &mut Self {
+        unsafe { core::mem::transmute(components) }
+    }
+}
+
+impl<T> PixelExt<T, 4> for Rgba<T> {
+    type PixelWithComponent<U> = Rgba<U>;
 }


### PR DESCRIPTION
Is my usage of `core::mem::transmute()` safe here? I couldn't find non-unsafe way of doing this.

If this is okay then I'll add implementations for the other Pixel types.