### PR TITLE
Associated array length rather than generic.

### DIFF
--- a/src/abgr.rs
+++ b/src/abgr.rs
@@ -9,9 +9,9 @@
 ///
 /// You can specify a different type for alpha, but it's only for special cases
 /// (e.g. if you use a newtype like `Abgr<LinearLight<u16>, u16>`).
-pub struct Abgr<T> {
+pub struct Abgr<T, A> {
     /// Alpha Component
-    pub a: T,
+    pub a: A,
     /// Blue Component
     pub b: T,
     /// Green Component

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,53 +1,47 @@
 /// A Pixel made up of a compile-time known number of contiguously stored `T`s.
 ///
 /// Usually `T` is a small copiable intrinsic type such as `u8`, `u16` or `f32`.
-pub trait HomogeneousPixel<T, const N: usize> {
+pub trait HomogeneousPixel<T> {
     /// The same pixel type as Self but with a different generic component type.
-    type PixelWithComponent<U>;
+    type SelfType<U>;
+    /// The array form of Self
+    type ArrayForm<R>;
 
     /// Converts an owned `Pixel` type to an array of its components.
-    fn components(&self) -> [T; N];
+    fn components(&self) -> Self::ArrayForm<T>;
     /// Converts an array of components to a `Pixel`.
-    fn from_components(components: [T; N]) -> Self;
+    fn from_components(components: Self::ArrayForm<T>) -> Self;
 
     /// Map the pixel to the same outer pixel type with an optionally different inner type.
-    fn map<U>(&self, f: impl FnMut(T) -> U) -> Self::PixelWithComponent<U>
+    fn map<U>(&self, f: impl FnMut(T) -> U) -> Self::SelfType<U>
     where
-        Self::PixelWithComponent<U>: HomogeneousPixel<U, N>,
-        Self: Copy,
-    {
-        Self::PixelWithComponent::from_components(self.components().map(f))
-    }
+        U: Copy;
 }
 
 /// A pixel with possibly differently typed color and alpha components.
-pub trait HeterogeneousPixel<T, A, const N: usize> {
+pub trait HeterogeneousPixel<T, A> {
     /// The same pixel type as Self but with a different generic component types.
-    type PixelWithComponent<U, B>;
+    type SelfType<U, B>;
+    /// The color array form of Self
+    type ColorArrayForm<R>;
 
     /// The color components
-    fn colors(&self) -> [T; N];
+    fn colors(&self) -> Self::ColorArrayForm<T>;
     /// The alpha component
     fn alpha(&self) -> A;
 
     /// Create a new instance given the color and alpha components.
-    fn from_colors_alpha(colors: [T; N], alpha: A) -> Self;
+    fn from_colors_alpha(colors: Self::ColorArrayForm<T>, alpha: A) -> Self;
 
     /// Map the pixel to the same outer pixel type with an optionally different inner color component
     /// type and the exact same alpha component.
-    fn map_colors<U>(&self, f: impl FnMut(T) -> U) -> Self::PixelWithComponent<U, A>
+    fn map_colors<U>(&self, f: impl FnMut(T) -> U) -> Self::SelfType<U, A>
     where
-        Self::PixelWithComponent<U, A>: HeterogeneousPixel<U, A, N>,
-    {
-        Self::PixelWithComponent::from_colors_alpha(self.colors().map(f), self.alpha())
-    }
+        U: Copy;
 
     /// Map the pixel to the same outer pixel type with an optionally different inner color component
     /// type and the exact same alpha component.
-    fn map_alpha<B>(&self, mut f: impl FnMut(A) -> B) -> Self::PixelWithComponent<T, B>
+    fn map_alpha<B>(&self, f: impl FnMut(A) -> B) -> Self::SelfType<T, B>
     where
-        Self::PixelWithComponent<T, B>: HeterogeneousPixel<T, B, N>,
-    {
-        Self::PixelWithComponent::from_colors_alpha(self.colors(), f(self.alpha()))
-    }
+        B: Copy;
 }

--- a/src/rgba.rs
+++ b/src/rgba.rs
@@ -22,11 +22,12 @@ pub struct Rgba<T, A = T> {
     pub a: A,
 }
 
-impl<T> HomogeneousPixel<T, 4> for Rgba<T>
+impl<T> HomogeneousPixel<T> for Rgba<T>
 where
     T: Copy,
 {
-    type PixelWithComponent<U> = Rgba<U>;
+    type SelfType<U> = Rgba<U>;
+    type ArrayForm<R> = [R; 4];
 
     fn components(&self) -> [T; 4] {
         [self.a, self.b, self.g, self.r]
@@ -42,14 +43,22 @@ where
             r: iter.next().unwrap(),
         }
     }
+
+    fn map<U>(&self, f: impl FnMut(T) -> U) -> Self::SelfType<U>
+    where
+        U: Copy,
+    {
+        Self::SelfType::from_components(self.components().map(f))
+    }
 }
 
-impl<T, A> HeterogeneousPixel<T, A, 3> for Rgba<T, A>
+impl<T, A> HeterogeneousPixel<T, A> for Rgba<T, A>
 where
     T: Copy,
     A: Copy,
 {
-    type PixelWithComponent<U, B> = Rgba<U, B>;
+    type SelfType<U, B> = Rgba<U, B>;
+    type ColorArrayForm<R> = [R; 3];
 
     fn colors(&self) -> [T; 3] {
         [self.r, self.g, self.b]
@@ -66,5 +75,18 @@ where
             b: colors[2],
             a: alpha,
         }
+    }
+
+    fn map_colors<U>(&self, f: impl FnMut(T) -> U) -> Self::SelfType<U, A>
+    where
+        U: Copy,
+    {
+        Self::SelfType::from_colors_alpha(self.colors().map(f), self.alpha())
+    }
+    fn map_alpha<B>(&self, mut f: impl FnMut(A) -> B) -> Self::SelfType<T, B>
+    where
+        B: Copy,
+    {
+        Self::SelfType::from_colors_alpha(self.colors(), f(self.alpha()))
     }
 }


### PR DESCRIPTION
This is an important change for the generic use of a pixel type since the `N` parameter is a leaky abstraction that should be inherent to each particular pixel.

This PR fixes that using another generic associated type for storing the fixed compile-time sized array type.

The drawback is that since we no-longer know the array size in the trait itself we can't provide default implementations, but I don't think that's much of a drawback as they are easy enough to implement on each type, especially with macros in case it gets repetitive like in `0.8`.