### PR TITLE
Minimal Trait Bounds + `IntoIterator` trait bound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ maintenance = { status = "actively-developed" }
 serde = { version = "1.0.130", optional = true, default-features = false, features = [
 	"derive",
 ] }
-num-traits = { version = "0.2.19", default-features = false }
 bytemuck = { version = "1.7.2", optional = true }
 defmt = { version = "0.3", optional = true }
 

--- a/src/pixel/het_pixel.rs
+++ b/src/pixel/het_pixel.rs
@@ -24,7 +24,7 @@ impl Display for TryFromColorsAlphaError {
 ///
 /// Component = An element of a pixel, inclusive of alpha. For example, [`Rgba`](crate::Rgba) is a pixel made up
 /// of four components, three color components and one alpha component.
-pub trait HetPixel: Copy {
+pub trait HetPixel: Sized {
     /// The component type of the pixel used the color component(s).
     type ColorComponent: PixelComponent;
     /// The component type of the pixel used the alpha component if any.

--- a/src/pixel/hom_pixel.rs
+++ b/src/pixel/hom_pixel.rs
@@ -28,6 +28,7 @@ impl Display for TryFromComponentsError {
 /// of four components, three color components and one alpha component.
 pub trait HomPixel:
     HetPixel<ColorComponent = Self::Component, AlphaComponent = Self::Component>
+    + IntoIterator<Item = Self::Component>
 {
     /// The component type of the pixel used for both color and alpha components if any.
     type Component: PixelComponent;

--- a/src/pixel/pixel_component.rs
+++ b/src/pixel/pixel_component.rs
@@ -1,7 +1,5 @@
-use num_traits::{Num, NumAssign, NumCast, NumOps};
-
 /// A trait for all the required super-traits for a pixel component type.
-pub trait PixelComponent: Copy + Num + NumCast + NumAssign + NumOps + PartialOrd<Self> {
+pub trait PixelComponent: Copy {
     /// The minimum component value
     const COMPONENT_MIN: Self;
     /// The maximum component value


### PR DESCRIPTION
I think I've changed my mind regarding using `num-traits`, I think it's better to offer the minimal number of trait bounds on the two `Pixel` traits and the `PixelComponent` trait since if a user requires those behaviours then they can always bound their functions with `num-traits` but on the other hand if a user has a type that does not implement one of those behaviours they cannot ever implement `HomPixel` or `HetPixel` even if they could provide all of the relevant methods. It also saves us a dependency as you mentioned.

I've also added a `IntoIterator` super-trait bound to `HomPixel` since that is a relevant trait that should never not be able to be implemented.