### PR TITLE
`num-traits` strikes back!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,7 @@ edition = "2021"
 [features]
 default = []
 
-# Enable `checked_add` and `checked_sub` methods on `RGB<u8>`
-checked_fns = []
-
+num-trait = ["dep:num-traits"]
 defmt-03 = ["dep:defmt"]
 serde = ["dep:serde"]
 bytemuck = ["dep:bytemuck"]
@@ -31,8 +29,9 @@ maintenance = { status = "actively-developed" }
 serde = { version = "1.0.130", optional = true, default-features = false, features = [
 	"derive",
 ] }
-bytemuck = { version = "1.7.2", optional = true }
-defmt = { version = "0.3", optional = true }
+bytemuck = { version = "1.7.2", optional = true, default-features = false }
+defmt = { version = "0.3", optional = true, default-features = false }
+num-traits = { version = "0.2.19", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.68"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 [features]
 default = []
 
-num-trait = ["dep:num-traits"]
+num-traits = ["dep:num-traits"]
 defmt-03 = ["dep:defmt"]
 serde = ["dep:serde"]
 bytemuck = ["dep:bytemuck"]

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -13,16 +13,7 @@ use core::fmt;
 use core::iter::Sum;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
-use abgr::Abgr;
-use argb::Argb;
-use bgr::Bgr;
-use bgra::Bgra;
-use gray::Gray;
-use grb::Grb;
-use rgb::Rgb;
-use rgba::Rgba;
-
-use crate::GrayA;
+use crate::{Abgr, Argb, Bgr, Bgra, Gray, GrayA, Grb, PixelComponent, Rgb, Rgba};
 
 macro_rules! hom_trait_impls {
 
@@ -135,7 +126,7 @@ macro_rules! hom_trait_impls {
 
             #[inline(always)]
             fn add(self, other: $name<T>) -> Self::Output {
-                $name {
+                Self::Output {
                     $(
                         $bit: self.$bit + other.$bit,
                     )+
@@ -150,7 +141,7 @@ macro_rules! hom_trait_impls {
 
             #[inline(always)]
             fn add(self, r: T) -> Self::Output {
-                $name {
+                Self::Output {
                     $(
                         $bit: self.$bit + r,
                     )+
@@ -177,7 +168,7 @@ macro_rules! hom_trait_impls {
         {
             #[inline(always)]
             fn add_assign(&mut self, r: T) {
-                *self = $name {
+                *self = Self {
                     $(
                         $bit: self.$bit + r,
                     )+
@@ -190,8 +181,8 @@ macro_rules! hom_trait_impls {
             type Output = $name<<T as Sub>::Output>;
 
             #[inline(always)]
-            fn sub(self, other: $name<T>) -> Self::Output {
-                $name {
+            fn sub(self, other: Self) -> Self::Output {
+                Self::Output {
                     $(
                         $bit: self.$bit - other.$bit,
                     )+
@@ -206,7 +197,7 @@ macro_rules! hom_trait_impls {
 
             #[inline(always)]
             fn sub(self, r: T) -> Self::Output {
-                $name {
+                Self::Output {
                     $(
                         $bit: self.$bit - r,
                     )+
@@ -233,7 +224,7 @@ macro_rules! hom_trait_impls {
         {
             #[inline(always)]
             fn sub_assign(&mut self, r: T) {
-                *self = $name {
+                *self = Self {
                     $(
                         $bit: self.$bit - r,
                     )+
@@ -246,8 +237,8 @@ macro_rules! hom_trait_impls {
             type Output = $name<<T as Mul>::Output>;
 
             #[inline(always)]
-            fn mul(self, other: $name<T>) -> Self::Output {
-                $name {
+            fn mul(self, other: Self) -> Self::Output {
+                Self::Output {
                     $(
                         $bit: self.$bit * other.$bit,
                     )+
@@ -262,7 +253,7 @@ macro_rules! hom_trait_impls {
 
             #[inline(always)]
             fn mul(self, r: T) -> Self::Output {
-                $name {
+                Self::Output {
                     $(
                         $bit: self.$bit * r,
                     )+
@@ -289,7 +280,7 @@ macro_rules! hom_trait_impls {
         {
             #[inline(always)]
             fn mul_assign(&mut self, r: T) {
-                *self = $name {
+                *self = Self {
                     $(
                         $bit: self.$bit * r,
                     )+
@@ -302,8 +293,8 @@ macro_rules! hom_trait_impls {
             type Output = $name<<T as Div>::Output>;
 
             #[inline(always)]
-            fn div(self, other: $name<T>) -> Self::Output {
-                $name {
+            fn div(self, other: Self) -> Self::Output {
+                Self::Output {
                     $(
                         $bit: self.$bit / other.$bit,
                     )+
@@ -318,7 +309,7 @@ macro_rules! hom_trait_impls {
 
             #[inline(always)]
             fn div(self, r: T) -> Self::Output {
-                $name {
+                Self::Output {
                     $(
                         $bit: self.$bit / r,
                     )+

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -8,11 +8,21 @@ pub mod grb;
 pub mod rgb;
 pub mod rgba;
 
-use crate::*;
 use core::array::TryFromSliceError;
 use core::fmt;
 use core::iter::Sum;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+
+use abgr::Abgr;
+use argb::Argb;
+use bgr::Bgr;
+use bgra::Bgra;
+use gray::Gray;
+use grb::Grb;
+use rgb::Rgb;
+use rgba::Rgba;
+
+use crate::GrayA;
 
 macro_rules! hom_trait_impls {
 
@@ -132,6 +142,21 @@ macro_rules! hom_trait_impls {
                 }
             }
         }
+        /// Allows writing `pixel + 1`
+        impl<T> Add<T> for $name<T> where
+            T: Copy + Add<Output=T>
+        {
+            type Output = $name<T>;
+
+            #[inline(always)]
+            fn add(self, r: T) -> Self::Output {
+                $name {
+                    $(
+                        $bit: self.$bit + r,
+                    )+
+                }
+            }
+        }
 
         /// Allows writing `pixel += pixel`
         impl<T> AddAssign for $name<T> where
@@ -142,6 +167,19 @@ macro_rules! hom_trait_impls {
                 *self = Self {
                     $(
                         $bit: self.$bit + other.$bit,
+                    )+
+                };
+            }
+        }
+        /// Allows writing `pixel += 1`
+        impl<T> AddAssign<T> for $name<T> where
+            T: Copy + Add<Output=T>
+        {
+            #[inline(always)]
+            fn add_assign(&mut self, r: T) {
+                *self = $name {
+                    $(
+                        $bit: self.$bit + r,
                     )+
                 };
             }
@@ -160,6 +198,21 @@ macro_rules! hom_trait_impls {
                 }
             }
         }
+        /// Allows writing `pixel - 1`
+        impl<T> Sub<T> for $name<T> where
+            T: Copy + Sub<Output=T>
+        {
+            type Output = $name<<T as Sub>::Output>;
+
+            #[inline(always)]
+            fn sub(self, r: T) -> Self::Output {
+                $name {
+                    $(
+                        $bit: self.$bit - r,
+                    )+
+                }
+            }
+        }
 
         /// Allows writing `pixel -= pixel`
         impl<T> SubAssign for $name<T> where
@@ -170,6 +223,19 @@ macro_rules! hom_trait_impls {
                 *self = Self {
                     $(
                         $bit: self.$bit - other.$bit,
+                    )+
+                };
+            }
+        }
+        /// Allows writing `pixel -= 1`
+        impl<T> SubAssign<T> for $name<T> where
+            T: Copy + Sub<Output=T>
+        {
+            #[inline(always)]
+            fn sub_assign(&mut self, r: T) {
+                *self = $name {
+                    $(
+                        $bit: self.$bit - r,
                     )+
                 };
             }
@@ -188,6 +254,21 @@ macro_rules! hom_trait_impls {
                 }
             }
         }
+        /// Allows writing `pixel * 2`
+        impl<T> Mul<T> for $name<T> where
+            T: Copy + Mul<Output=T>
+        {
+            type Output = $name<T>;
+
+            #[inline(always)]
+            fn mul(self, r: T) -> Self::Output {
+                $name {
+                    $(
+                        $bit: self.$bit * r,
+                    )+
+                }
+            }
+        }
 
         /// Allows writing `pixel *= pixel`
         impl<T> MulAssign for $name<T> where
@@ -198,6 +279,19 @@ macro_rules! hom_trait_impls {
                 *self = Self {
                     $(
                         $bit: self.$bit * other.$bit,
+                    )+
+                };
+            }
+        }
+        /// Allows writing `pixel *= 2`
+        impl<T> MulAssign<T> for $name<T> where
+            T: Copy + Mul<Output=T>
+        {
+            #[inline(always)]
+            fn mul_assign(&mut self, r: T) {
+                *self = $name {
+                    $(
+                        $bit: self.$bit * r,
                     )+
                 };
             }
@@ -216,112 +310,6 @@ macro_rules! hom_trait_impls {
                 }
             }
         }
-
-        /// Allows writing `pixel /= pixel`
-        impl<T> DivAssign for $name<T> where
-            T: Div<Output = T> + Copy
-        {
-            #[inline(always)]
-            fn div_assign(&mut self, other: $name<T>) {
-                *self = Self {
-                    $(
-                        $bit: self.$bit / other.$bit,
-                    )+
-                };
-            }
-        }
-
-        /// Allows writing `pixel + 1`
-        impl<T> Add<T> for $name<T> where
-            T: Copy + Add<Output=T>
-        {
-            type Output = $name<T>;
-
-            #[inline(always)]
-            fn add(self, r: T) -> Self::Output {
-                $name {
-                    $(
-                        $bit: self.$bit + r,
-                    )+
-                }
-            }
-        }
-
-        /// Allows writing `pixel += 1`
-        impl<T> AddAssign<T> for $name<T> where
-            T: Copy + Add<Output=T>
-        {
-            #[inline(always)]
-            fn add_assign(&mut self, r: T) {
-                *self = $name {
-                    $(
-                        $bit: self.$bit + r,
-                    )+
-                };
-            }
-        }
-
-        /// Allows writing `pixel - 1`
-        impl<T> Sub<T> for $name<T> where
-            T: Copy + Sub<Output=T>
-        {
-            type Output = $name<<T as Sub>::Output>;
-
-            #[inline(always)]
-            fn sub(self, r: T) -> Self::Output {
-                $name {
-                    $(
-                        $bit: self.$bit - r,
-                    )+
-                }
-            }
-        }
-
-        /// Allows writing `pixel -= 1`
-        impl<T> SubAssign<T> for $name<T> where
-            T: Copy + Sub<Output=T>
-        {
-            #[inline(always)]
-            fn sub_assign(&mut self, r: T) {
-                *self = $name {
-                    $(
-                        $bit: self.$bit - r,
-                    )+
-                };
-            }
-        }
-
-
-        /// Allows writing `pixel * 2`
-        impl<T> Mul<T> for $name<T> where
-            T: Copy + Mul<Output=T>
-        {
-            type Output = $name<T>;
-
-            #[inline(always)]
-            fn mul(self, r: T) -> Self::Output {
-                $name {
-                    $(
-                        $bit: self.$bit * r,
-                    )+
-                }
-            }
-        }
-
-        /// Allows writing `pixel *= 2`
-        impl<T> MulAssign<T> for $name<T> where
-            T: Copy + Mul<Output=T>
-        {
-            #[inline(always)]
-            fn mul_assign(&mut self, r: T) {
-                *self = $name {
-                    $(
-                        $bit: self.$bit * r,
-                    )+
-                };
-            }
-        }
-
         /// Allows writing `pixel / 2`
         impl<T> Div<T> for $name<T> where
             T: Copy + Div<Output=T>
@@ -338,6 +326,19 @@ macro_rules! hom_trait_impls {
             }
         }
 
+        /// Allows writing `pixel /= pixel`
+        impl<T> DivAssign for $name<T> where
+            T: Div<Output = T> + Copy
+        {
+            #[inline(always)]
+            fn div_assign(&mut self, other: $name<T>) {
+                *self = Self {
+                    $(
+                        $bit: self.$bit / other.$bit,
+                    )+
+                };
+            }
+        }
         /// Allows writing `pixel /= 2`
         impl<T> DivAssign<T> for $name<T> where
             T: Copy + Div<Output=T>

--- a/src/from.rs
+++ b/src/from.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use crate::{Abgr, Argb, Bgr, Bgra, Gray, GrayA, Grb, Rgb, Rgba};
 
 macro_rules! without_alpha {
     ($from_type:ident, $self_type:ident, {$($bit:tt),*}) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 mod formats;
 mod from;
 mod pixel;
+mod num_traits;
 
 pub use formats::abgr::Abgr;
 pub use formats::argb::Argb;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,9 @@
 
 mod formats;
 mod from;
-mod pixel;
+#[cfg(feature = "num-traits")]
 mod num_traits;
+mod pixel;
 
 pub use formats::abgr::Abgr;
 pub use formats::argb::Argb;

--- a/src/num_traits.rs
+++ b/src/num_traits.rs
@@ -1,0 +1,229 @@
+macro_rules! num_traits {
+($name:ident, [$($bit:tt),*]) => {
+    /// Allows writing `pixel + pixel`
+    impl<T: Add> Add for $name<T> {
+        type Output = $name<<T as Add>::Output>;
+
+        #[inline(always)]
+        fn add(self, other: $name<T>) -> Self::Output {
+            $name {
+                $(
+                    $bit: self.$bit + other.$bit,
+                )+
+            }
+        }
+    }
+    /// Allows writing `pixel + 1`
+    impl<T> Add<T> for $name<T> where
+        T: Copy + Add<Output=T>
+    {
+        type Output = $name<T>;
+
+        #[inline(always)]
+        fn add(self, r: T) -> Self::Output {
+            $name {
+                $(
+                    $bit: self.$bit + r,
+                )+
+            }
+        }
+    }
+
+    /// Allows writing `pixel += pixel`
+    impl<T> AddAssign for $name<T> where
+        T: Add<Output = T> + Copy
+    {
+        #[inline(always)]
+        fn add_assign(&mut self, other: $name<T>) {
+            *self = Self {
+                $(
+                    $bit: self.$bit + other.$bit,
+                )+
+            };
+        }
+    }
+    /// Allows writing `pixel += 1`
+    impl<T> AddAssign<T> for $name<T> where
+        T: Copy + Add<Output=T>
+    {
+        #[inline(always)]
+        fn add_assign(&mut self, r: T) {
+            *self = $name {
+                $(
+                    $bit: self.$bit + r,
+                )+
+            };
+        }
+    }
+
+    /// Allows writing `pixel - pixel`
+    impl<T: Sub> Sub for $name<T> {
+        type Output = $name<<T as Sub>::Output>;
+
+        #[inline(always)]
+        fn sub(self, other: $name<T>) -> Self::Output {
+            $name {
+                $(
+                    $bit: self.$bit - other.$bit,
+                )+
+            }
+        }
+    }
+    /// Allows writing `pixel - 1`
+    impl<T> Sub<T> for $name<T> where
+        T: Copy + Sub<Output=T>
+    {
+        type Output = $name<<T as Sub>::Output>;
+
+        #[inline(always)]
+        fn sub(self, r: T) -> Self::Output {
+            $name {
+                $(
+                    $bit: self.$bit - r,
+                )+
+            }
+        }
+    }
+
+    /// Allows writing `pixel -= pixel`
+    impl<T> SubAssign for $name<T> where
+        T: Sub<Output = T> + Copy
+    {
+        #[inline(always)]
+        fn sub_assign(&mut self, other: $name<T>) {
+            *self = Self {
+                $(
+                    $bit: self.$bit - other.$bit,
+                )+
+            };
+        }
+    }
+    /// Allows writing `pixel -= 1`
+    impl<T> SubAssign<T> for $name<T> where
+        T: Copy + Sub<Output=T>
+    {
+        #[inline(always)]
+        fn sub_assign(&mut self, r: T) {
+            *self = $name {
+                $(
+                    $bit: self.$bit - r,
+                )+
+            };
+        }
+    }
+
+    /// Allows writing `pixel * pixel`
+    impl<T: Mul> Mul for $name<T> {
+        type Output = $name<<T as Mul>::Output>;
+
+        #[inline(always)]
+        fn mul(self, other: $name<T>) -> Self::Output {
+            $name {
+                $(
+                    $bit: self.$bit * other.$bit,
+                )+
+            }
+        }
+    }
+    /// Allows writing `pixel * 2`
+    impl<T> Mul<T> for $name<T> where
+        T: Copy + Mul<Output=T>
+    {
+        type Output = $name<T>;
+
+        #[inline(always)]
+        fn mul(self, r: T) -> Self::Output {
+            $name {
+                $(
+                    $bit: self.$bit * r,
+                )+
+            }
+        }
+    }
+
+    /// Allows writing `pixel *= pixel`
+    impl<T> MulAssign for $name<T> where
+        T: Mul<Output = T> + Copy
+    {
+        #[inline(always)]
+        fn mul_assign(&mut self, other: $name<T>) {
+            *self = Self {
+                $(
+                    $bit: self.$bit * other.$bit,
+                )+
+            };
+        }
+    }
+    /// Allows writing `pixel *= 2`
+    impl<T> MulAssign<T> for $name<T> where
+        T: Copy + Mul<Output=T>
+    {
+        #[inline(always)]
+        fn mul_assign(&mut self, r: T) {
+            *self = $name {
+                $(
+                    $bit: self.$bit * r,
+                )+
+            };
+        }
+    }
+
+    /// Allows writing `pixel / pixel`
+    impl<T: Div> Div for $name<T> {
+        type Output = $name<<T as Div>::Output>;
+
+        #[inline(always)]
+        fn div(self, other: $name<T>) -> Self::Output {
+            $name {
+                $(
+                    $bit: self.$bit / other.$bit,
+                )+
+            }
+        }
+    }
+    /// Allows writing `pixel / 2`
+    impl<T> Div<T> for $name<T> where
+        T: Copy + Div<Output=T>
+    {
+        type Output = $name<T>;
+
+        #[inline(always)]
+        fn div(self, r: T) -> Self::Output {
+            $name {
+                $(
+                    $bit: self.$bit / r,
+                )+
+            }
+        }
+    }
+
+    /// Allows writing `pixel /= pixel`
+    impl<T> DivAssign for $name<T> where
+        T: Div<Output = T> + Copy
+    {
+        #[inline(always)]
+        fn div_assign(&mut self, other: $name<T>) {
+            *self = Self {
+                $(
+                    $bit: self.$bit / other.$bit,
+                )+
+            };
+        }
+    }
+    /// Allows writing `pixel /= 2`
+    impl<T> DivAssign<T> for $name<T> where
+        T: Copy + Div<Output=T>
+    {
+        #[inline(always)]
+        fn div_assign(&mut self, r: T) {
+            *self = $name {
+                $(
+                    $bit: self.$bit / r,
+                )+
+            };
+        }
+    }
+};
+}
+
+num_traits!(Rgb, [r, g, b]);

--- a/src/num_traits.rs
+++ b/src/num_traits.rs
@@ -1,229 +1,61 @@
+use crate::{Abgr, Argb, Bgr, Bgra, Gray, GrayA, Grb, Rgb, Rgba};
+
+use num_traits::ops::checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
+
 macro_rules! num_traits {
 ($name:ident, [$($bit:tt),*]) => {
-    /// Allows writing `pixel + pixel`
-    impl<T: Add> Add for $name<T> {
-        type Output = $name<<T as Add>::Output>;
-
+    impl<T: CheckedAdd> CheckedAdd for $name<T> {
         #[inline(always)]
-        fn add(self, other: $name<T>) -> Self::Output {
-            $name {
+        fn checked_add(&self, other: &Self) -> Option<Self> {
+            Some(Self {
                 $(
-                    $bit: self.$bit + other.$bit,
+                    $bit: self.$bit.checked_add(&other.$bit)?,
                 )+
-            }
-        }
-    }
-    /// Allows writing `pixel + 1`
-    impl<T> Add<T> for $name<T> where
-        T: Copy + Add<Output=T>
-    {
-        type Output = $name<T>;
-
-        #[inline(always)]
-        fn add(self, r: T) -> Self::Output {
-            $name {
-                $(
-                    $bit: self.$bit + r,
-                )+
-            }
+            })
         }
     }
 
-    /// Allows writing `pixel += pixel`
-    impl<T> AddAssign for $name<T> where
-        T: Add<Output = T> + Copy
-    {
+    impl<T: CheckedSub> CheckedSub for $name<T> {
         #[inline(always)]
-        fn add_assign(&mut self, other: $name<T>) {
-            *self = Self {
+        fn checked_sub(&self, other: &Self) -> Option<Self> {
+            Some(Self {
                 $(
-                    $bit: self.$bit + other.$bit,
+                    $bit: self.$bit.checked_sub(&other.$bit)?,
                 )+
-            };
-        }
-    }
-    /// Allows writing `pixel += 1`
-    impl<T> AddAssign<T> for $name<T> where
-        T: Copy + Add<Output=T>
-    {
-        #[inline(always)]
-        fn add_assign(&mut self, r: T) {
-            *self = $name {
-                $(
-                    $bit: self.$bit + r,
-                )+
-            };
+            })
         }
     }
 
-    /// Allows writing `pixel - pixel`
-    impl<T: Sub> Sub for $name<T> {
-        type Output = $name<<T as Sub>::Output>;
-
+    impl<T: CheckedMul> CheckedMul for $name<T> {
         #[inline(always)]
-        fn sub(self, other: $name<T>) -> Self::Output {
-            $name {
+        fn checked_mul(&self, other: &Self) -> Option<Self> {
+            Some(Self {
                 $(
-                    $bit: self.$bit - other.$bit,
+                    $bit: self.$bit.checked_mul(&other.$bit)?,
                 )+
-            }
-        }
-    }
-    /// Allows writing `pixel - 1`
-    impl<T> Sub<T> for $name<T> where
-        T: Copy + Sub<Output=T>
-    {
-        type Output = $name<<T as Sub>::Output>;
-
-        #[inline(always)]
-        fn sub(self, r: T) -> Self::Output {
-            $name {
-                $(
-                    $bit: self.$bit - r,
-                )+
-            }
+            })
         }
     }
 
-    /// Allows writing `pixel -= pixel`
-    impl<T> SubAssign for $name<T> where
-        T: Sub<Output = T> + Copy
-    {
+    impl<T: CheckedDiv> CheckedDiv for $name<T> {
         #[inline(always)]
-        fn sub_assign(&mut self, other: $name<T>) {
-            *self = Self {
+        fn checked_div(&self, other: &Self) -> Option<Self> {
+            Some(Self {
                 $(
-                    $bit: self.$bit - other.$bit,
+                    $bit: self.$bit.checked_div(&other.$bit)?,
                 )+
-            };
-        }
-    }
-    /// Allows writing `pixel -= 1`
-    impl<T> SubAssign<T> for $name<T> where
-        T: Copy + Sub<Output=T>
-    {
-        #[inline(always)]
-        fn sub_assign(&mut self, r: T) {
-            *self = $name {
-                $(
-                    $bit: self.$bit - r,
-                )+
-            };
-        }
-    }
-
-    /// Allows writing `pixel * pixel`
-    impl<T: Mul> Mul for $name<T> {
-        type Output = $name<<T as Mul>::Output>;
-
-        #[inline(always)]
-        fn mul(self, other: $name<T>) -> Self::Output {
-            $name {
-                $(
-                    $bit: self.$bit * other.$bit,
-                )+
-            }
-        }
-    }
-    /// Allows writing `pixel * 2`
-    impl<T> Mul<T> for $name<T> where
-        T: Copy + Mul<Output=T>
-    {
-        type Output = $name<T>;
-
-        #[inline(always)]
-        fn mul(self, r: T) -> Self::Output {
-            $name {
-                $(
-                    $bit: self.$bit * r,
-                )+
-            }
-        }
-    }
-
-    /// Allows writing `pixel *= pixel`
-    impl<T> MulAssign for $name<T> where
-        T: Mul<Output = T> + Copy
-    {
-        #[inline(always)]
-        fn mul_assign(&mut self, other: $name<T>) {
-            *self = Self {
-                $(
-                    $bit: self.$bit * other.$bit,
-                )+
-            };
-        }
-    }
-    /// Allows writing `pixel *= 2`
-    impl<T> MulAssign<T> for $name<T> where
-        T: Copy + Mul<Output=T>
-    {
-        #[inline(always)]
-        fn mul_assign(&mut self, r: T) {
-            *self = $name {
-                $(
-                    $bit: self.$bit * r,
-                )+
-            };
-        }
-    }
-
-    /// Allows writing `pixel / pixel`
-    impl<T: Div> Div for $name<T> {
-        type Output = $name<<T as Div>::Output>;
-
-        #[inline(always)]
-        fn div(self, other: $name<T>) -> Self::Output {
-            $name {
-                $(
-                    $bit: self.$bit / other.$bit,
-                )+
-            }
-        }
-    }
-    /// Allows writing `pixel / 2`
-    impl<T> Div<T> for $name<T> where
-        T: Copy + Div<Output=T>
-    {
-        type Output = $name<T>;
-
-        #[inline(always)]
-        fn div(self, r: T) -> Self::Output {
-            $name {
-                $(
-                    $bit: self.$bit / r,
-                )+
-            }
-        }
-    }
-
-    /// Allows writing `pixel /= pixel`
-    impl<T> DivAssign for $name<T> where
-        T: Div<Output = T> + Copy
-    {
-        #[inline(always)]
-        fn div_assign(&mut self, other: $name<T>) {
-            *self = Self {
-                $(
-                    $bit: self.$bit / other.$bit,
-                )+
-            };
-        }
-    }
-    /// Allows writing `pixel /= 2`
-    impl<T> DivAssign<T> for $name<T> where
-        T: Copy + Div<Output=T>
-    {
-        #[inline(always)]
-        fn div_assign(&mut self, r: T) {
-            *self = $name {
-                $(
-                    $bit: self.$bit / r,
-                )+
-            };
+            })
         }
     }
 };
 }
 
 num_traits!(Rgb, [r, g, b]);
+num_traits!(Bgr, [b, g, r]);
+num_traits!(Grb, [g, r, b]);
+num_traits!(Rgba, [r, g, b, a]);
+num_traits!(Argb, [a, r, g, b]);
+num_traits!(Bgra, [b, g, r, a]);
+num_traits!(Abgr, [a, b, g, r]);
+num_traits!(Gray, [0]);
+num_traits!(GrayA, [0, 1]);

--- a/src/pixel/arraylike.rs
+++ b/src/pixel/arraylike.rs
@@ -1,8 +1,9 @@
-use crate::*;
 use core::{
     borrow::{Borrow, BorrowMut},
     ops::{Index, IndexMut},
 };
+
+use crate::PixelComponent;
 
 /// A trait used when returning arrays from the two pixel traits due to the lack of the const
 /// generic expression feature on stable rust.

--- a/src/pixel/gain_alpha.rs
+++ b/src/pixel/gain_alpha.rs
@@ -1,5 +1,6 @@
 use crate::HetPixel;
 use crate::PixelComponent;
+use crate::{Abgr, Argb, Bgr, Bgra, Gray, GrayA, Grb, Rgb, Rgba};
 
 /// A pixel which can gain an alpha component.
 pub trait GainAlpha: HetPixel {

--- a/src/pixel/gain_alpha.rs
+++ b/src/pixel/gain_alpha.rs
@@ -1,4 +1,5 @@
-use crate::*;
+use crate::HetPixel;
+use crate::PixelComponent;
 
 /// A pixel which can gain an alpha component.
 pub trait GainAlpha: HetPixel {

--- a/src/pixel/has_alpha.rs
+++ b/src/pixel/has_alpha.rs
@@ -1,4 +1,10 @@
-use crate::*;
+use crate::Abgr;
+use crate::Argb;
+use crate::Bgra;
+use crate::GrayA;
+use crate::HetPixel;
+use crate::PixelComponent;
+use crate::Rgba;
 
 /// A pixel which has an alpha component.
 pub trait HasAlpha: HetPixel {

--- a/src/pixel/het_pixel.rs
+++ b/src/pixel/het_pixel.rs
@@ -1,6 +1,6 @@
 use core::fmt::Display;
 
-use crate::*;
+use crate::{Abgr, Argb, ArrayLike, Bgr, Bgra, Gray, GrayA, Grb, PixelComponent, Rgb, Rgba};
 
 #[derive(Debug, Clone, Copy)]
 /// Error returned from the [`HetPixel::try_from_colors_alpha()`] function.

--- a/src/pixel/hom_pixel.rs
+++ b/src/pixel/hom_pixel.rs
@@ -1,6 +1,8 @@
 use core::fmt::Display;
 
-use crate::*;
+use crate::{
+    Abgr, Argb, ArrayLike, Bgr, Bgra, Gray, GrayA, Grb, HetPixel, PixelComponent, Rgb, Rgba,
+};
 
 #[derive(Debug, Clone, Copy)]
 /// Error returned from the [`HomPixel::try_from_components()`] function.


### PR DESCRIPTION
Optionally adds implementations of the `Checked{Add,Sub..}` traits from `num-traits` as opposed to doing it manually via inherent methods as in `v0.8` which means it can be used generically unlike the inherent methods.

I also refactored the normal inherent macro a bit and switched all the glob imports to normal imports.

The dependencies now all have `default-features = false` as well.