### PR TITLE
mut-methods

### DIFF
--- a/src/formats/abgr.rs
+++ b/src/formats/abgr.rs
@@ -1,5 +1,6 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// An `ABGR` pixel.
 pub struct Abgr<T, A = T> {

--- a/src/formats/argb.rs
+++ b/src/formats/argb.rs
@@ -1,5 +1,6 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// An `ARGB` pixel.
 pub struct Argb<T, A = T> {

--- a/src/formats/bgr.rs
+++ b/src/formats/bgr.rs
@@ -1,5 +1,6 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `BGR` pixel.
 pub struct Bgr<T> {

--- a/src/formats/bgra.rs
+++ b/src/formats/bgra.rs
@@ -1,5 +1,6 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `BGRA` pixel.
 pub struct Bgra<T, A = T> {

--- a/src/formats/gray.rs
+++ b/src/formats/gray.rs
@@ -1,5 +1,6 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Grayscale` pixel.
 pub struct Gray<T>(

--- a/src/formats/gray_a.rs
+++ b/src/formats/gray_a.rs
@@ -1,5 +1,6 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Grayscale + Alpha` pixel.
 pub struct GrayA<T, A = T>(

--- a/src/formats/grb.rs
+++ b/src/formats/grb.rs
@@ -1,5 +1,6 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `GRB` pixel.
 pub struct Grb<T> {

--- a/src/formats/rgb.rs
+++ b/src/formats/rgb.rs
@@ -1,5 +1,6 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// An `RGB` pixel.
 pub struct Rgb<T> {

--- a/src/formats/rgba.rs
+++ b/src/formats/rgba.rs
@@ -1,5 +1,6 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// An `RGBA` pixel.
 pub struct Rgba<T, A = T> {

--- a/src/pixel/arraylike.rs
+++ b/src/pixel/arraylike.rs
@@ -3,16 +3,13 @@ use core::{
     ops::{Index, IndexMut},
 };
 
-use crate::PixelComponent;
-
 /// A trait used when returning arrays from the two pixel traits due to the lack of the const
 /// generic expression feature on stable rust.
 ///
 /// A blanket implementation is provided but only for item types which implement
 /// [`PixelComponent`].
 pub trait ArrayLike<T>:
-    Copy
-    + AsRef<[T]>
+    AsRef<[T]>
     + AsMut<[T]>
     + Index<usize, Output = T>
     + IndexMut<usize>
@@ -21,4 +18,4 @@ pub trait ArrayLike<T>:
     + IntoIterator<Item = T>
 {
 }
-impl<T, const N: usize> ArrayLike<T> for [T; N] where T: PixelComponent {}
+impl<T, const N: usize> ArrayLike<T> for [T; N] {}

--- a/src/pixel/has_alpha.rs
+++ b/src/pixel/has_alpha.rs
@@ -8,10 +8,10 @@ use crate::Rgba;
 
 /// A pixel which has an alpha component.
 pub trait HasAlpha: HetPixel {
-    /// Returns the pixels alpha component.
-    ///
-    /// Use [`HetPixel::try_from_colors_alpha()`] to set the pixels alpha component.
+    /// Returns a copy of the pixel's alpha component.
     fn alpha(&self) -> Self::AlphaComponent;
+    /// Returns a mutable borrow of the pixel's alpha component.
+    fn alpha_mut(&mut self) -> &mut Self::AlphaComponent;
 }
 
 macro_rules! has_alpha {
@@ -23,6 +23,9 @@ macro_rules! has_alpha {
         {
             fn alpha(&self) -> Self::AlphaComponent {
                 self.$alpha_bit
+            }
+            fn alpha_mut(&mut self) -> &mut Self::AlphaComponent {
+                &mut self.$alpha_bit
             }
         }
     };

--- a/src/pixel/het_pixel.rs
+++ b/src/pixel/het_pixel.rs
@@ -43,10 +43,16 @@ pub trait HetPixel: Copy + 'static {
     >;
 
     //TODO switch to returning an plain array if const generic expressions ever stabilize
-    /// Converts an owned `Pixel` type to an array of its color components.
-    fn color_array(&self) -> impl ArrayLike<Self::ColorComponent>;
-    /// Returns the alpha component of the pixel if it has one.
+    /// Returns an owned array of copies of the pixels color components.
+    fn color_array(&self) -> impl ArrayLike<Self::ColorComponent> + Copy;
+    //TODO switch to returning an plain array if const generic expressions ever stabilize
+    /// Returns an owned array of the pixel's mutably borrowed color components.
+    fn color_array_mut(&mut self) -> impl ArrayLike<&mut Self::ColorComponent>;
+
+    /// Returns a copy of the pixel's alpha alpha component if it has one.
     fn alpha_checked(&self) -> Option<Self::AlphaComponent>;
+    /// Returns a mutable borrow of the pixel's alpha alpha component if it has one.
+    fn alpha_checked_mut(&mut self) -> Option<&mut Self::AlphaComponent>;
 
     /// Tries to create new instance given an iterator of color components and an alpha component.
     ///
@@ -106,10 +112,17 @@ macro_rules! without_alpha {
 
             type SelfType<U: PixelComponent, V: PixelComponent> = $name<U>;
 
-            fn color_array(&self) -> impl ArrayLike<Self::ColorComponent> {
+            fn color_array(&self) -> impl ArrayLike<Self::ColorComponent> + Copy {
                 [$(self.$color_bit),*]
             }
+            fn color_array_mut(&mut self) -> impl ArrayLike<&mut Self::ColorComponent> {
+                [$(&mut self.$color_bit),*]
+            }
+
             fn alpha_checked(&self) -> Option<Self::AlphaComponent> {
+                None
+            }
+            fn alpha_checked_mut(&mut self) -> Option<&mut Self::AlphaComponent> {
                 None
             }
 
@@ -165,11 +178,18 @@ macro_rules! with_alpha {
 
             type SelfType<U: PixelComponent, V: PixelComponent> = $name<U, V>;
 
-            fn color_array(&self) -> impl ArrayLike<Self::ColorComponent> {
+            fn color_array(&self) -> impl ArrayLike<Self::ColorComponent> + Copy {
                 [$(self.$color_bit),*]
             }
+            fn color_array_mut(&mut self) -> impl ArrayLike<&mut Self::ColorComponent> {
+                [$(&mut self.$color_bit),*]
+            }
+
             fn alpha_checked(&self) -> Option<Self::AlphaComponent> {
                 Some(self.$alpha_bit)
+            }
+            fn alpha_checked_mut(&mut self) -> Option<&mut Self::AlphaComponent> {
+                Some(&mut self.$alpha_bit)
             }
 
             fn try_from_colors_alpha(

--- a/src/pixel/hom_pixel.rs
+++ b/src/pixel/hom_pixel.rs
@@ -36,8 +36,11 @@ pub trait HomPixel:
     type Component: PixelComponent;
 
     //TODO switch to returning an plain array if const generic expressions ever stabilize
-    /// Converts an owned `Pixel` type to an array of its components.
-    fn component_array(&self) -> impl ArrayLike<Self::Component>;
+    /// Returns an owned array of copies of the pixels components.
+    fn component_array(&self) -> impl ArrayLike<Self::Component> + Copy;
+    //TODO switch to returning an plain array if const generic expressions ever stabilize
+    /// Returns an owned array of the pixel's mutably borrowed components.
+    fn component_array_mut(&mut self) -> impl ArrayLike<&mut Self::Component>;
 
     /// Tries to create new instance given an iterator of its components.
     ///
@@ -68,8 +71,11 @@ macro_rules! without_alpha {
         {
             type Component = T;
 
-            fn component_array(&self) -> impl ArrayLike<Self::Component> {
+            fn component_array(&self) -> impl ArrayLike<Self::Component> + Copy {
                 [$(self.$bit),*]
+            }
+            fn component_array_mut(&mut self) -> impl ArrayLike<&mut Self::Component> {
+                [$(&mut self.$bit),*]
             }
 
             fn try_from_components(
@@ -99,8 +105,11 @@ macro_rules! with_alpha {
         {
             type Component = T;
 
-            fn component_array(&self) -> impl ArrayLike<Self::Component> {
+            fn component_array(&self) -> impl ArrayLike<Self::Component> + Copy {
                 [$(self.$bit),*]
+            }
+            fn component_array_mut(&mut self) -> impl ArrayLike<&mut Self::Component> {
+                [$(&mut self.$bit),*]
             }
 
             fn try_from_components(


### PR DESCRIPTION
To be reviewed after #96

Although not strictly necessary the `mut` methods are quite convenient and possibly more efficient in some scenarios depending on how well the compiler optimizes certain operations these are convenient for.