### PR TITLE
Add doc examples to everything and reword normal docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# `struct RGB` for [Rust](https://www.rust-lang.org)  [![crate](https://img.shields.io/crates/v/rgb.svg)](https://lib.rs/crates/rgb)
+# Pixel types for [Rust](https://www.rust-lang.org) [![crate](https://img.shields.io/crates/v/rgb.svg)](https://lib.rs/crates/rgb)
 
-Operating on pixels as weakly-typed vectors of `u8` is error-prone and inconvenient. It's better to use vectors of pixel structs. However, Rust is so strongly typed that *your* RGB pixel struct is not compatible with *my* RGB pixel struct. So let's all use mine :P
+Operating on pixels as weakly-typed vectors of `u8` is error-prone and inconvenient. It's better to use vectors of pixel structs. However, Rust is so strongly typed that _your_ `Rgb` pixel struct is not compatible with _my_ `Rgb` pixel struct. So let's all use mine :P
 
 [![xkcd standards](https://imgs.xkcd.com/comics/standards.png)](https://xkcd.com/927/)
 
@@ -10,61 +10,5 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rgb = "0.8"
+rgb = "0.9"
 ```
-
-## Usage
-
-### `RGB` and `RGBA` structs
-
-The structs implement common Rust traits and a few convenience functions, e.g. `map` that repeats an operation on every subpixel:
-
-```rust
-use rgb::*; // Laziest way to use traits which add extra methods to the structs
-
-let px = RGB {
-    r:255_u8,
-    g:0,
-    b:255,
-};
-let inverted = px.map(|ch| 255 - ch);
-
-println!("{}", inverted); // Display: rgb(0,255,0)
-assert_eq!(RGB8::new(0, 255, 0), inverted);
-```
-
-### Byte slices to pixel slices
-
-For interoperability with functions operating on generic arrays of bytes there are functions for safe casting to and from pixel slices.
-
-```rust
-let raw = vec![0u8; width*height*3];
-let pixels: &[RGB8] = raw.as_rgb(); /// Safe casts without copying
-let raw_again = pixels.as_bytes();
-```
-
-Note: if you get an error about "no method named `as_bytes` found", add `use rgb::ComponentBytes`. If you're using a custom component type (`RGB<CustomType>`), implement `rgb::Pod` (plain old data) and `rgb::Zeroable` trait for the component (these traits are from [`bytemuck`](https://lib.rs/bytemuck) crate).
-
-----
-
-## About colorspaces
-
-*Correct* color management is a complex problem, and this crate aims to be the lowest common denominator, so it's intentionally agnostic about it.
-
-However, this library supports any subpixel type for `RGB<T>`, and `RGBA<RGBType, AlphaType>`, so you can use them with a newtype, e.g.:
-
-```rust
-struct LinearLight(u16);
-type LinearRGB = RGB<LinearLight>;
-```
-
-
-### `BGRA`, `ARGB`, `Gray`, etc.
-
-There are other color types in `rgb::alt::*`. To enable `ARGB` and `ABGR`, use the "argb" feature:
-
-```toml
-rgb = { version = "0.8", features = ["argb"] }
-```
-
-There's also an optional `serde` feature that makes all types (de)serializable.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,140 @@ Add this to your `Cargo.toml`:
 [dependencies]
 rgb = "0.9"
 ```
+
+## Usage
+
+### Pixel Types
+
+This crate offers the following pixel types:
+
+```rust
+use rgb::{Rgb, Rgba, Argb, Bgr, Bgra, Abgr, Grb, Luma, LumaA};
+
+let rgb = Rgb {r: 0, g: 0, b: 0};
+let rbga = Rgba {r: 0, g: 0, b: 0, a: 0};
+let argb = Argb {a: 0, r: 0, g: 0, b: 0};
+
+let bgr = Bgr {b: 0, g: 0, r: 0};
+let bgra = Bgra {b: 0, g: 0, r: 0, a: 0};
+let abgr = Abgr {r: 0, g: 0, b: 0, a: 0};
+
+let grb = Grb {g: 0, b: 0, r: 0};
+
+let luma = Luma {l: 0};
+let luma_a = LumaA {l: 0, a: 0};
+```
+
+If you have a pixel type you would like to use that is not currently
+implemented, please open an issue to request your pixel type.
+
+The pixel types with an alpha component such as `Rgba` have two
+generic type parameters:
+
+```rust
+struct Rgba<T, A = T> {
+    r: T,
+    g: T,
+    b: T,
+    a: A,
+}
+```
+
+This makes them more flexible for more use-cases, for example if you
+needed more precision for you color components than your alpha
+component you could create an `Rgba<f32, u8>`. However, in most
+use-cases the alpha component type will be the same as the color
+component type.
+
+A pixel with separate types for the color and alpha
+components is called a heterogeneous pixel whereas a pixel with a
+single type for both color and alpha components is called a
+homogeneous pixel.
+
+### Pixel Traits
+
+All functionality for the pixel types is implemented via traits. This
+means that none of the pixel types, like `Rgb<u8>`, have any inherent
+methods. This makes it easy to choose which methods you'd like to be
+in scope at any given time unlike inherent methods which are always
+within scope.
+
+This crate offers the following traits:
+
+#### HetPixel
+
+The most foundational pixel trait implemented by every pixel type.
+
+```rust
+use rgb::{Rgba, HetPixel};
+
+let mut rgba: Rgba<u8> = Rgba::try_from_colors_alpha([0, 0, 0], 0).unwrap();
+
+*rgba.color_array_mut()[2] = u8::MAX;
+assert_eq!(rgba.color_array(), [0, 0, 255]);
+
+*rgba.alpha_checked_mut().unwrap() = 50;
+assert_eq!(rgba.alpha_checked(), Some(50));
+
+let rgba = rgba.map_colors(u16::from);
+let rgba = rgba.map_colors_same(|c| c * 2);
+let rgba = rgba.map_alpha(f32::from);
+let rgba = rgba.map_alpha_same(|a| a * 2.0);
+
+assert_eq!(rgba, Rgba::<u16, f32> {r: 0, g: 0, b: 510, a: 100.0});
+```
+
+#### HomPixel
+
+A stricter form of `HetPixel` where the two component types, color and
+alpha, are the same.
+
+```rust
+use rgb::{Rgba, HomPixel};
+
+let mut rgba: Rgba<u8> = Rgba::try_from_components([0, 0, 0, 0]).unwrap();
+
+*rgba.component_array_mut()[2] = u8::MAX;
+assert_eq!(rgba.component_array(), [0, 0, 255, 0]);
+
+let rgba = rgba.map_components(u16::from);
+let rgba = rgba.map_components_same(|c| c * 2);
+
+assert_eq!(rgba, Rgba::<u16> {r: 0, g: 0, b: 510, a: 0});
+```
+
+#### GainAlpha
+
+A way to add alpha to a pixel type in various ways.
+
+```rust
+use rgb::{Rgb, Rgba, GainAlpha};
+
+let expected: Rgba<u8> = Rgba {r: 0, g: 0, b: 0, a: 255};
+
+assert_eq!(Rgb {r: 0, g: 0, b: 0}.gain_alpha(), expected);
+assert_eq!(Rgb {r: 0, g: 0, b: 0}.gain_alpha_with(255), expected);
+assert_eq!(Rgba {r: 0, g: 0, b: 0, a: 0}.gain_alpha_exact(255), expected);
+```
+
+#### HasAlpha
+
+A trait only implemented on pixels that have an alpha
+component.
+
+```rust
+use rgb::{Rgba, HasAlpha};
+
+let mut rgba: Rgba<u8> = Rgba {r: 0, g: 0, b: 0, a: 255};
+
+*rgba.alpha_mut() -= 50;
+
+assert_eq!(rgba.alpha(), 205);
+```
+
+## Color-Space Agnostic
+
+This crate is purposefully agnostic about the color-spaces of the
+pixel types. For example, `Gray<u8>` could be either linear lightness or
+gamma-corrected lightness, or `Rgb<u8>` could be normal `srgb` or
+`linear-srgb`.

--- a/src/pixel/arraylike.rs
+++ b/src/pixel/arraylike.rs
@@ -4,10 +4,10 @@ use core::{
 };
 
 /// A trait used when returning arrays from the two pixel traits due to the lack of the const
-/// generic expression feature on stable rust.
+/// generic expressions feature on stable rust.
 ///
-/// A blanket implementation is provided but only for item types which implement
-/// [`PixelComponent`].
+/// See [`HetPixel::color_array()`](crate::HetPixel::color_array) as
+/// an example.
 pub trait ArrayLike<T>:
     AsRef<[T]>
     + AsMut<[T]>

--- a/src/pixel/gain_alpha.rs
+++ b/src/pixel/gain_alpha.rs
@@ -8,26 +8,69 @@ use crate::{Abgr, Argb, Bgr, Bgra, Rgb, Rgba};
 use crate::{Gray, GrayAlpha};
 
 /// A pixel which can gain an alpha component.
+///
+/// It's implemented for every pixel type in the crate, including those which
+/// already have an alpha component.
 pub trait GainAlpha: HetPixel {
     /// The pixel type after gaining an alpha component.
+    /// 
+    /// For example, for `Rgb`: `GainAlpha = Rgba`.
     type GainAlpha: HasAlpha;
 
     /// Returns the pixel type after gaining an alpha component.
     ///
-    /// If an alpha is already contained then it remains at the same value. If no alpha component
-    /// is already contained then it is set to the maximum value via [`PixelComponent`].
+    /// If an alpha is already contained then it remains at the same value. If
+    /// no alpha component is already contained then it is set to the maximum
+    /// value via [`PixelComponent`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rgb::{Rgb, Rgba, GainAlpha};
+    ///
+    /// let rgb = Rgb {r: 0_u8, g: 10, b: 100};
+    /// let rgba = Rgba {r: 0_u8, g: 10, b: 100, a: 50};
+    ///
+    /// assert_eq!(rgb.gain_alpha(), Rgba {r: 0, g: 10, b: 100, a: 255});
+    /// assert_eq!(rgba.gain_alpha(), Rgba {r: 0, g: 10, b: 100, a: 50});
+    /// ```
     fn gain_alpha(self) -> Self::GainAlpha;
 
     /// Returns the pixel type after gaining an alpha component.
     ///
-    /// If an alpha is already contained then it remains at the same value. If no alpha component
-    /// is already contained then it is set to the given `alpha` value.
+    /// If an alpha is already contained then it remains at the same value. If
+    /// no alpha component is already contained then it is set to the given
+    /// `alpha` value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rgb::{Rgb, Rgba, GainAlpha};
+    ///
+    /// let rgb = Rgb {r: 0_u8, g: 10, b: 100};
+    /// let rgba = Rgba {r: 0_u8, g: 10, b: 100, a: 50};
+    ///
+    /// assert_eq!(rgb.gain_alpha_with(0), Rgba {r: 0, g: 10, b: 100, a: 0});
+    /// assert_eq!(rgba.gain_alpha_with(0), Rgba {r: 0, g: 10, b: 100, a: 50});
+    /// ```
     fn gain_alpha_with(self, alpha: Self::AlphaComponent) -> Self::GainAlpha;
 
     /// Returns the pixel type after gaining an alpha component.
     ///
-    /// The alpha value is set to the given `alpha` value regardless of whether the pixel already
-    /// contained an alpha component.
+    /// The alpha value is set to the given `alpha` value regardless of whether
+    /// the pixel already contained an alpha component.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rgb::{Rgb, Rgba, GainAlpha};
+    ///
+    /// let rgb = Rgb {r: 0_u8, g: 10, b: 100};
+    /// let rgba = Rgba {r: 0_u8, g: 10, b: 100, a: 50};
+    ///
+    /// assert_eq!(rgb.gain_alpha_exact(0), Rgba {r: 0, g: 10, b: 100, a: 0});
+    /// assert_eq!(rgba.gain_alpha_exact(0), Rgba {r: 0, g: 10, b: 100, a: 0});
+    /// ```
     fn gain_alpha_exact(self, alpha: Self::AlphaComponent) -> Self::GainAlpha;
 }
 

--- a/src/pixel/has_alpha.rs
+++ b/src/pixel/has_alpha.rs
@@ -6,10 +6,39 @@ use crate::PixelComponent;
 use crate::{Abgr, Argb, Bgra, LumaA, Rgba};
 
 /// A pixel which has an alpha component.
+///
+/// This trait is implemented only for those types in the crate that
+/// contain an alpha component, such as [`Rgba`].
 pub trait HasAlpha: HetPixel {
     /// Returns a copy of the pixel's alpha component.
+    ///
+    /// # Examples
+    /// ```
+    /// use rgb::{Rgba, HasAlpha};
+    ///
+    /// let mut rgba = Rgba {r: 0_u8, g: 10, b: 100, a: 50};
+    ///
+    /// assert_eq!(rgba.alpha(), 50);
+    ///
+    /// rgba.a = 0;
+    ///
+    /// assert_eq!(rgba.alpha(), 0);
+    /// ```
     fn alpha(&self) -> Self::AlphaComponent;
     /// Returns a mutable borrow of the pixel's alpha component.
+    ///
+    /// # Examples
+    /// ```
+    /// use rgb::{Rgba, HasAlpha};
+    ///
+    /// let mut rgba = Rgba {r: 0_u8, g: 10, b: 100, a: 50};
+    ///
+    /// let alpha = rgba.alpha_mut();
+    ///
+    /// *alpha += 100;
+    ///
+    /// assert_eq!(rgba.alpha(), 150);
+    /// ```
     fn alpha_mut(&mut self) -> &mut Self::AlphaComponent;
 }
 

--- a/src/pixel/het_pixel.rs
+++ b/src/pixel/het_pixel.rs
@@ -23,11 +23,6 @@ impl Display for TryFromColorsAlphaError {
 /// components.
 ///
 /// This trait is implemented on every pixel type in the crate.
-///
-/// # Terminology
-///
-/// Component = An element of a pixel, inclusive of alpha. For example, [`Rgba`](crate::Rgba) is a pixel made up
-/// of four components, three color components and one alpha component.
 pub trait HetPixel: Copy + 'static {
     /// The component type of the pixel used the color component(s).
     type ColorComponent: PixelComponent;

--- a/src/pixel/het_pixel.rs
+++ b/src/pixel/het_pixel.rs
@@ -19,7 +19,7 @@ impl Display for TryFromColorsAlphaError {
 /// A Pixel made up of a compile-time known number of color components and optionally an
 /// alpha component.
 ///
-/// Unlike [`HomPixel`] the alpha component does not have to be the same type as the color
+/// Unlike [`HomPixel`](crate::HomPixel) the alpha component does not have to be the same type as the color
 /// components.
 ///
 /// This trait is implemented on every pixel type in the crate.

--- a/src/pixel/hom_pixel.rs
+++ b/src/pixel/hom_pixel.rs
@@ -27,11 +27,6 @@ impl Display for TryFromComponentsError {
 /// This trait is implemented on every pixel type in the crate.
 ///
 /// All types which implement [`HomPixel`] also implement [`HetPixel`] due to the super-trait trait bound.
-///
-/// # Terminology
-///
-/// Component = An element of a pixel, inclusive of alpha. For example, [`Rgba`](crate::Rgba) is a pixel made up
-/// of four components, three color components and one alpha component.
 pub trait HomPixel:
     HetPixel<ColorComponent = Self::Component, AlphaComponent = Self::Component>
     + IntoIterator<Item = Self::Component>

--- a/src/pixel/pixel_component.rs
+++ b/src/pixel/pixel_component.rs
@@ -49,6 +49,12 @@ macro_rules! float {
         }
     };
 }
+
+impl PixelComponent for bool {
+    const COMPONENT_MIN: Self = false;
+    const COMPONENT_MAX: Self = true;
+}
+
 integer!(u8);
 integer!(u16);
 integer!(u32);

--- a/src/pixel/pixel_component.rs
+++ b/src/pixel/pixel_component.rs
@@ -1,4 +1,31 @@
 /// A trait for all the required super-traits for a pixel component type.
+///
+/// Implementations are provided for all intrinsic types.
+///
+/// Integers such as `u8` set [`PixelComponent::COMPONENT_MIN`]
+/// equal to [`u8::MIN`] and [`PixelComponent::COMPONENT_MAX`] to
+/// [`u8::MAX`].
+///
+/// Floats such as `f32` set [`PixelComponent::COMPONENT_MIN`]
+/// equal to `0.0` and [`PixelComponent::COMPONENT_MAX`] to
+/// `1.0`.
+///
+/// If you require a different range for one of the intrinstic types,
+/// make a newtype such as:
+///
+/// # Examples
+///
+/// ```
+/// use rgb::PixelComponent;
+///
+/// #[derive(Clone, Copy)]
+/// struct FullRangeF32(f32);
+///
+/// impl PixelComponent for FullRangeF32 {
+///     const COMPONENT_MIN: Self = Self(f32::MIN);
+///     const COMPONENT_MAX: Self = Self(f32::MAX);
+/// }
+/// ```
 pub trait PixelComponent: Copy + 'static {
     /// The minimum component value
     const COMPONENT_MIN: Self;


### PR DESCRIPTION
One non-doctest related change was reverting back to `ColorArray` and `ComponentArray` associated types which was found to be more flexible than the `-> impl ArrayLike` return type as it lets the compiler figure out conditional trait impls in non-generic contexts.

For example the `color_array()` doc-test compiles with the associated types version but not the `-> impl ArrayLike` version since the compiler can figure out PartialEq is implemented on the  first version but not the second:
```rust
use rgb::{HetPixel, Rgb, Rgba};

let rgb = Rgb {r: 0_u8, g: 10, b: 100};
let rgba = Rgba {r: 0_u8, g: 10, b: 100, a: 50};

assert_eq!(rgb.color_array(), [0, 10, 100]);
assert_eq!(rgba.color_array(), [0, 10, 100]);
```

I also added an implementation of `PixelComponent` for `bool` which would possibly be used for binary images with `Gray<bool>`.

The `README.md` usage section was also updated to show the new traits and how they can be used.