### PR TITLE
Add `Rgbw` Pixel

### DIFF
--- a/src/bytemuck.rs
+++ b/src/bytemuck.rs
@@ -1,4 +1,4 @@
-use crate::{Abgr, Argb, Bgr, Bgra, Grb, Luma, LumaA, Rgb, Rgba};
+use crate::{Abgr, Argb, Bgr, Bgra, Grb, Luma, LumaA, Rgb, Rgba, Rgbw};
 #[cfg(feature = "legacy")]
 use crate::{Gray, GrayAlpha};
 
@@ -12,6 +12,7 @@ macro_rules! bytemuck {
 bytemuck!(Rgb);
 bytemuck!(Bgr);
 bytemuck!(Grb);
+bytemuck!(Rgbw);
 #[cfg(feature = "legacy")]
 bytemuck!(Gray);
 bytemuck!(Luma);

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -9,11 +9,14 @@ pub mod luma;
 pub mod luma_a;
 pub mod rgb;
 pub mod rgba;
+pub mod rgbw;
 
 use core::array::TryFromSliceError;
 use core::fmt;
 use core::iter::Sum;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+
+use rgbw::Rgbw;
 
 use crate::{Abgr, Argb, Bgr, Bgra, Grb, Luma, LumaA, PixelComponent, Rgb, Rgba};
 #[cfg(feature = "legacy")]
@@ -353,6 +356,7 @@ macro_rules! hom_trait_impls {
 hom_trait_impls!(Rgb, 3, [r:0, g:1, b:2], "rgb({}, {}, {})", "rgb(#{:02X}{:02X}{:02X})", "rgb(#{:02x}{:02x}{:02x})");
 hom_trait_impls!(Bgr, 3, [b:0, g:1, r:2], "bgr({}, {}, {})", "bgr(#{:02X}{:02X}{:02X})", "bgr(#{:02x}{:02x}{:02x})");
 hom_trait_impls!(Grb, 3, [g:0, r:1, b:2], "grb({}, {}, {})", "grb(#{:02X}{:02X}{:02X})", "grb(#{:02x}{:02x}{:02x})");
+hom_trait_impls!(Rgbw, 4, [r:0, g:1, b:2, w:3], "rgbw({}, {}, {}, {})", "rgbw(#{:02X}{:02X}{:02X}{:02X})", "rgbw(#{:02x}{:02x}{:02x}{:02x})");
 hom_trait_impls!(Rgba, 4, [r:0, g:1, b:2, a:3], "rgba({}, {}, {}, {})", "rgba(#{:02X}{:02X}{:02X}{:02X})", "rgba(#{:02x}{:02x}{:02x}{:02x})");
 hom_trait_impls!(Argb, 4, [a:0, r:1, g:2, b:3], "argb({}, {}, {}, {})", "argb(#{:02X}{:02X}{:02X}{:02X})", "argb(#{:02x}{:02x}{:02x}{:02x})");
 hom_trait_impls!(Bgra, 4, [b:0, g:1, r:2, a:3], "bgra({}, {}, {}, {})", "bgra(#{:02X}{:02X}{:02X}{:02X})", "bgra(#{:02x}{:02x}{:02x}{:02x})");

--- a/src/formats/rgbw.rs
+++ b/src/formats/rgbw.rs
@@ -1,0 +1,15 @@
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+/// An `Red + Green + Blue + White` pixel.
+pub struct Rgbw<T> {
+    /// Red Component
+    pub r: T,
+    /// Green Component
+    pub g: T,
+    /// Blue Component
+    pub b: T,
+    /// White Component
+    pub w: T,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub use formats::luma::Luma;
 pub use formats::luma_a::LumaA;
 pub use formats::rgb::Rgb;
 pub use formats::rgba::Rgba;
+pub use formats::rgbw::Rgbw;
 
 pub use pixel::{
     arraylike::ArrayLike,

--- a/src/num_traits.rs
+++ b/src/num_traits.rs
@@ -1,4 +1,4 @@
-use crate::{Abgr, Argb, Bgr, Bgra, Grb, Luma, LumaA, Rgb, Rgba};
+use crate::{Abgr, Argb, Bgr, Bgra, Grb, Luma, LumaA, Rgb, Rgba, Rgbw};
 #[cfg(feature = "legacy")]
 use crate::{Gray, GrayAlpha};
 
@@ -55,6 +55,7 @@ macro_rules! num_traits {
 num_traits!(Rgb, [r, g, b]);
 num_traits!(Bgr, [b, g, r]);
 num_traits!(Grb, [g, r, b]);
+num_traits!(Rgbw, [r, g, b, w]);
 #[cfg(feature = "legacy")]
 num_traits!(Gray, [0]);
 num_traits!(Luma, [l]);

--- a/src/pixel/het_pixel.rs
+++ b/src/pixel/het_pixel.rs
@@ -1,6 +1,6 @@
 use core::fmt::Display;
 
-use crate::{Abgr, Argb, ArrayLike, Bgr, Bgra, Grb, Luma, LumaA, PixelComponent, Rgb, Rgba};
+use crate::{Abgr, Argb, ArrayLike, Bgr, Bgra, Grb, Luma, LumaA, PixelComponent, Rgb, Rgba, Rgbw};
 #[cfg(feature = "legacy")]
 use crate::{Gray, GrayAlpha};
 
@@ -413,6 +413,7 @@ with_alpha!(LumaA, 2, [l], a);
 without_alpha!(Bgr, 3, [b, g, r]);
 without_alpha!(Rgb, 3, [r, g, b]);
 without_alpha!(Grb, 3, [r, g, b]);
+without_alpha!(Rgbw, 4, [r, g, b, w]);
 #[cfg(feature = "legacy")]
 without_alpha!(Gray, 1, [0]);
 without_alpha!(Luma, 1, [l]);

--- a/src/pixel/hom_pixel.rs
+++ b/src/pixel/hom_pixel.rs
@@ -1,7 +1,7 @@
 use core::fmt::Display;
 
 use crate::{
-    Abgr, Argb, ArrayLike, Bgr, Bgra, Grb, HetPixel, Luma, LumaA, PixelComponent, Rgb, Rgba,
+    Abgr, Argb, ArrayLike, Bgr, Bgra, Grb, HetPixel, Luma, LumaA, PixelComponent, Rgb, Rgba, Rgbw,
 };
 #[cfg(feature = "legacy")]
 use crate::{Gray, GrayAlpha};
@@ -235,6 +235,7 @@ with_alpha!(LumaA, 2, [l, a]);
 without_alpha!(Bgr, 3, [b, g, r]);
 without_alpha!(Rgb, 3, [r, g, b]);
 without_alpha!(Grb, 3, [r, g, b]);
+without_alpha!(Rgbw, 4, [r, g, b, w]);
 #[cfg(feature = "legacy")]
 without_alpha!(Gray, 1, [0]);
 without_alpha!(Luma, 1, [l]);


### PR DESCRIPTION
Fixes #21 

One concern I have when implementing the `Rgbw` pixel type is what `From<>` implementations to add since converting to `Rgb` and `Bgr` seems possible but could be lossy since the white component would be lost which could change the color quite drastically whereas all the other current `From` conversions simply change the memory layout of the same components.

For this reason I have not added any `From` conversions with the existing pixel types.