### PR TITLE
More doc-tests and bytemuck section in the `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,14 @@ Add this to your `Cargo.toml`:
 rgb = "0.9"
 ```
 
-## Usage
+## Color-Space Agnostic
 
-### Pixel Types
+This crate is purposefully agnostic about the color-spaces of the
+pixel types. For example, `Gray<u8>` could be either linear lightness or
+gamma-corrected lightness, or `Rgb<u8>` could be normal `srgb` or
+`linear-srgb`.
+
+## Pixel Types
 
 This crate offers the following pixel types:
 
@@ -62,7 +67,7 @@ components is called a heterogeneous pixel whereas a pixel with a
 single type for both color and alpha components is called a
 homogeneous pixel.
 
-### Pixel Traits
+## Pixel Traits
 
 All functionality for the pixel types is implemented via traits. This
 means that none of the pixel types, like `Rgb<u8>`, have any inherent
@@ -72,7 +77,7 @@ within scope.
 
 This crate offers the following traits:
 
-#### HetPixel
+### HetPixel
 
 The most foundational pixel trait implemented by every pixel type.
 
@@ -95,7 +100,7 @@ let rgba = rgba.map_alpha_same(|a| a * 2.0);
 assert_eq!(rgba, Rgba::<u16, f32> {r: 0, g: 0, b: 510, a: 100.0});
 ```
 
-#### HomPixel
+### HomPixel
 
 A stricter form of `HetPixel` where the two component types, color and
 alpha, are the same.
@@ -143,9 +148,38 @@ let mut rgba: Rgba<u8> = Rgba {r: 0, g: 0, b: 0, a: 255};
 assert_eq!(rgba.alpha(), 205);
 ```
 
-## Color-Space Agnostic
+## Bytemuck
 
-This crate is purposefully agnostic about the color-spaces of the
-pixel types. For example, `Gray<u8>` could be either linear lightness or
-gamma-corrected lightness, or `Rgb<u8>` could be normal `srgb` or
-`linear-srgb`.
+If you have a `&[u8]` or `Vec<u8>` type and you want a `&[Rgb<u8>]` or
+`Vec<Rgb<u8>>` type then you can safely achieve these type-casts via
+the `bytemuck` crate (see `cast_slice()` and `cast_vec()`).
+
+You will need to enable the `bytemuck` crate feature in order to use
+functions from the `bytemuck` library on the pixel types in this
+crate.
+
+## Crate Features
+
+- `default`: The default feature which does nothing.
+- `num-traits`: Enables various
+  [`num_traits`](https://docs.rs/num-traits) traits impls for the
+  pixel types such as `CheckedAdd`.
+- `defmt-03` = Enables the `Format` trait impls from
+  [`defmt`](https://docs.rs/defmt) `v0.3` for the pixel types
+- `serde` = Enables `Serializable` and `Deserializable` trait impls
+  from [`serde`](https://docs.rs/serde) for the pixel types
+- `bytemuck` = Enables `Pod` and `Zeroable` trait impls from
+  [`bytemuck`](https://docs.rs/serde) for the pixel types
+
+### Legacy Features
+
+The following crate features are only exposed for compatibility with
+the `v0.8` release so as to be non-breaking, however, once migrated to
+`v0.9` you should no longer be using any of these features. They are
+going to be removed in the next major release after `v0.9`.
+
+legacy = ["as-bytes"]
+argb = []
+grb = []
+checked_fns = []
+as-bytes = ["bytemuck"]

--- a/src/formats/abgr.rs
+++ b/src/formats/abgr.rs
@@ -3,6 +3,14 @@
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// An `Alpha + Blue + Green + Red` pixel.
+///
+/// # Examples
+///
+/// ```
+/// use rgb::Abgr;
+///
+/// let pixel: Abgr<u8> = Abgr { a: 255, b: 0, g: 0, r: 0 };
+/// ```
 pub struct Abgr<T, A = T> {
     /// Alpha Component
     pub a: A,

--- a/src/formats/argb.rs
+++ b/src/formats/argb.rs
@@ -3,6 +3,14 @@
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// An `Alpha + Red + Green + Blue` pixel.
+///
+/// # Examples
+///
+/// ```
+/// use rgb::Argb;
+///
+/// let pixel: Argb<u8> = Argb { a: 255, r: 0, g: 0, b: 0 };
+/// ```
 pub struct Argb<T, A = T> {
     /// Alpha Component
     pub a: A,

--- a/src/formats/bgr.rs
+++ b/src/formats/bgr.rs
@@ -3,6 +3,14 @@
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Blue + Green + Red` pixel.
+///
+/// # Examples
+///
+/// ```
+/// use rgb::Bgr;
+///
+/// let pixel: Bgr<u8> = Bgr { b: 0, g: 0, r: 0 };
+/// ```
 pub struct Bgr<T> {
     /// Blue Component
     pub b: T,

--- a/src/formats/bgra.rs
+++ b/src/formats/bgra.rs
@@ -3,6 +3,14 @@
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Blue + Green + Red + Alpha` pixel.
+///
+/// # Examples
+///
+/// ```
+/// use rgb::Bgra;
+///
+/// let pixel: Bgra<u8> = Bgra { b: 0, g: 0, r: 0, a: 255 };
+/// ```
 pub struct Bgra<T, A = T> {
     /// Blue Component
     pub b: T,

--- a/src/formats/grb.rs
+++ b/src/formats/grb.rs
@@ -3,6 +3,14 @@
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Green + Red + Blue` pixel.
+///
+/// # Examples
+///
+/// ```
+/// use rgb::Grb;
+///
+/// let pixel: Grb<u8> = Grb { g: 0, r: 0, b: 0 };
+/// ```
 pub struct Grb<T> {
     /// Green Component
     pub g: T,

--- a/src/formats/luma.rs
+++ b/src/formats/luma.rs
@@ -5,6 +5,14 @@
 /// A `Brightness` pixel.
 ///
 /// This pixel is commonly used for grayscale images.
+///
+/// # Examples
+///
+/// ```
+/// use rgb::Luma;
+///
+/// let pixel: Luma<u8> = Luma { l: 0 };
+/// ```
 pub struct Luma<T> {
     /// Brightness Component
     pub l: T,

--- a/src/formats/luma_a.rs
+++ b/src/formats/luma_a.rs
@@ -5,6 +5,14 @@
 /// A `Brightness + Alpha` pixel.
 ///
 /// This pixel is commonly used for grayscale images.
+///
+/// # Examples
+///
+/// ```
+/// use rgb::LumaA;
+///
+/// let pixel: LumaA<u8> = LumaA { l: 0, a: 255 };
+/// ```
 pub struct LumaA<T, A = T> {
     /// Brightness Component
     pub l: T,

--- a/src/formats/rgb.rs
+++ b/src/formats/rgb.rs
@@ -3,6 +3,14 @@
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// An `Red + Green + Blue` pixel.
+///
+/// # Examples
+///
+/// ```
+/// use rgb::Rgb;
+///
+/// let pixel: Rgb<u8> = Rgb { r: 0, g: 0, b: 0 };
+/// ```
 pub struct Rgb<T> {
     /// Red Component
     pub r: T,

--- a/src/formats/rgba.rs
+++ b/src/formats/rgba.rs
@@ -3,6 +3,14 @@
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// An `Red + Green + Blue + Alpha` pixel.
+///
+/// # Examples
+///
+/// ```
+/// use rgb::Rgba;
+///
+/// let pixel: Rgba<u8> = Rgba { r: 0, g: 0, b: 0, a: 255 };
+/// ```
 pub struct Rgba<T, A = T> {
     /// Red Component
     pub r: T,

--- a/src/formats/rgbw.rs
+++ b/src/formats/rgbw.rs
@@ -3,6 +3,14 @@
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// An `Red + Green + Blue + White` pixel.
+///
+/// # Examples
+///
+/// ```
+/// use rgb::Rgbw;
+///
+/// let pixel: Rgbw<u8> = Rgbw { r: 0, g: 0, b: 0, w: 0 };
+/// ```
 pub struct Rgbw<T> {
     /// Red Component
     pub r: T,


### PR DESCRIPTION
Adds a doc-test for each pixel type to show an initialization example, and a short section in the readme about using `bytemuck`.