### PR TITLE
Tweaks to the new commits on `v0.9`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ let rgba = rgba.map_same(|c| c * 2);
 assert_eq!(rgba, Rgba::<u16> {r: 0, g: 0, b: 510, a: 0});
 ```
 
-#### GainAlpha
+### GainAlpha
 
 A way to add alpha to a pixel type in various ways.
 
@@ -136,7 +136,7 @@ assert_eq!(Rgb {r: 0, g: 0, b: 0}.with_alpha(255), expected);
 assert_eq!(Rgba {r: 0, g: 0, b: 0, a: 0}.with_alpha(255), expected);
 ```
 
-#### HasAlpha
+### HasAlpha
 
 A trait only implemented on pixels that have an alpha
 component.

--- a/src/formats/gray.rs
+++ b/src/formats/gray.rs
@@ -24,6 +24,7 @@ pub struct Gray_v08<T>(
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[doc(alias = "Luma")]
+#[doc(alias = "Mono")]
 #[doc(alias = "GRAY8")]
 #[doc(alias = "GRAY16")]
 pub struct Gray_v09<T> {

--- a/src/formats/rgb.rs
+++ b/src/formats/rgb.rs
@@ -2,7 +2,7 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-/// An `Red + Green + Blue` pixel.
+/// A `Red + Green + Blue` pixel.
 ///
 /// # Examples
 ///

--- a/src/formats/rgba.rs
+++ b/src/formats/rgba.rs
@@ -2,7 +2,7 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-/// An `Red + Green + Blue + Alpha` pixel.
+/// A `Red + Green + Blue + Alpha` pixel.
 ///
 /// # Examples
 ///

--- a/src/formats/rgbw.rs
+++ b/src/formats/rgbw.rs
@@ -2,7 +2,7 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-/// An `Red + Green + Blue + White` pixel.
+/// A `Red + Green + Blue + White` pixel.
 ///
 /// # Examples
 ///

--- a/src/inherent_impls.rs
+++ b/src/inherent_impls.rs
@@ -1,13 +1,17 @@
-
-use crate::{Abgr, Argb, Bgr, Bgra, Grb, Gray, GrayA, Rgb, Rgba, Rgbw};
+use crate::{Abgr, Argb, Bgr, Bgra, Gray, GrayA, Grb, Rgb, Rgba, Rgbw};
 
 macro_rules! inherent_impls {
     ($name:ident, $new_fn:ident, [$($field:tt $var:ident),*]) => {
         impl<T: Copy + 'static> $name<T> {
-            #[doc=concat!("`", stringify!($name))]
-            /// {
-            #[doc=stringify!($($field,)*)]
-            /// }`
+            #[doc=concat!("Creates a new [`", stringify!($name), "`] pixel type from its components.")]
+            ///
+            /// Alternatively, you can use struct literal syntax to
+            /// create the new pixel type:
+            ///```not_rust
+            #[doc=concat!("use rgb::", stringify!($name), ";")]
+            ///
+            #[doc=concat!("let pixel = ", stringify!($name), " {", stringify!($($field: $var),*), "};")]
+            ///```
             pub const fn $new_fn($($var: T),*) -> Self {
                 Self {$($field: $var),*}
             }

--- a/src/inherent_impls.rs
+++ b/src/inherent_impls.rs
@@ -19,7 +19,7 @@ inherent_impls!(Rgb, new, [r red, g green, b blue]);
 inherent_impls!(Bgr, new_bgr, [b blue, g green, r red]);
 inherent_impls!(Grb, new_grb, [g green, r red, b blue]);
 inherent_impls!(Gray, new, [v value]);
-inherent_impls!(Rgbw, new, [r red, g green, b blue, w white]);
+inherent_impls!(Rgbw, new_rgbw, [r red, g green, b blue, w white]);
 
 #[cfg(feature = "legacy")]
 use crate::formats::gray::Gray_v08;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,5 @@ pub use pixel_traits::{
     pixel::Pixel,
 };
 
-/// TryFrom errors
-pub mod error {
-    pub use crate::pixel_traits::het_pixel::TryFromColorsAlphaError;
-    pub use crate::pixel_traits::pixel::TryFromComponentsError;
-}
+pub use crate::pixel_traits::het_pixel::TryFromColorsAlphaError;
+pub use crate::pixel_traits::pixel::TryFromComponentsError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ mod formats {
     pub mod rgbw;
 }
 mod core_traits;
-mod impls;
+mod inherent_impls;
 mod from;
 mod tuples;
 mod pixel_traits {

--- a/src/pixel_traits/gain_alpha.rs
+++ b/src/pixel_traits/gain_alpha.rs
@@ -29,7 +29,6 @@ pub trait GainAlpha: HetPixel {
     /// assert_eq!(rgb.with_default_alpha(0), Rgba {r: 0, g: 10, b: 100, a: 0});
     /// assert_eq!(rgba.with_default_alpha(0), Rgba {r: 0, g: 10, b: 100, a: 50});
     /// ```
-    #[doc(alias = "gain_alpha_with")]
     #[doc(alias = "gain_alpha")]
     fn with_default_alpha(self, alpha: Self::AlphaComponent) -> Self::GainAlpha;
 
@@ -49,7 +48,7 @@ pub trait GainAlpha: HetPixel {
     /// assert_eq!(rgb.with_alpha(0), Rgba {r: 0, g: 10, b: 100, a: 0});
     /// assert_eq!(rgba.with_alpha(0), Rgba {r: 0, g: 10, b: 100, a: 0});
     /// ```
-    #[doc(alias = "gain_alpha_exact")]
+    #[doc(alias = "gain_alpha")]
     fn with_alpha(self, alpha: Self::AlphaComponent) -> Self::GainAlpha;
 }
 

--- a/src/pixel_traits/het_pixel.rs
+++ b/src/pixel_traits/het_pixel.rs
@@ -153,7 +153,7 @@ pub trait HetPixel: Copy + 'static {
     /// # Examples
     ///
     /// ```
-    /// use rgb::{HetPixel, Rgb, Rgba, error::TryFromColorsAlphaError};
+    /// use rgb::{HetPixel, Rgb, Rgba, TryFromColorsAlphaError};
     ///
     /// let mut values2 = [0_u8, 10];
     /// let mut values4 = [0_u8, 10, 100, 40];

--- a/src/pixel_traits/het_pixel.rs
+++ b/src/pixel_traits/het_pixel.rs
@@ -59,7 +59,7 @@ pub trait HetPixel: Copy + 'static {
         SelfType<Self::ColorComponent, Self::AlphaComponent> = Self,
     >;
 
-    /// An generic associated type used to return the array of color
+    /// A generic associated type used to return the array of color
     /// components despite rust's lack of const generic expressions.
     ///
     /// Used in functions like [`HetPixel::color_array()`].

--- a/src/pixel_traits/het_pixel.rs
+++ b/src/pixel_traits/het_pixel.rs
@@ -1,5 +1,5 @@
-use core::fmt::Display;
 use crate::{Abgr, Argb, ArrayLike, Bgr, Bgra, Gray, GrayA, Grb, Rgb, Rgba, Rgbw};
+use core::fmt::Display;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Error returned from the [`HetPixel::try_from_colors_alpha()`] function.
@@ -41,16 +41,16 @@ pub trait HetPixel: Copy + 'static {
     /// [`Rgba`] has a `COMPONENTS` == 4.
     const COMPONENTS: u8;
 
-    /// Number of components minus alpha
+    /// The number of components in the pixel minus alpha.
     ///
-    /// * `Rgba` has `COLOR_COMPONENTS` == 3.
-    /// * `Rgbw` has `COLOR_COMPONENTS` == 4.
+    /// For example, [`Rgb`] has a `COLOR_COMPONENTS` == 3 whereas
+    /// [`Rgbw`] has a `COLOR_COMPONENTS` == 4.
     const COLOR_COMPONENTS: u8;
 
     /// The same pixel type as `Self` but with a different component type `U`.
     ///
     /// This is used to allow the implementation of
-    /// [`HetPixel::map_colors`] and similar methods due to rust's
+    /// [`HetPixel::map_colors()`] and similar methods due to rust's
     /// current lack of higher kinded types.
     ///
     /// For example, [`Rgb`] has `SelfType<U, V> = Rgb<U>` whereas
@@ -117,9 +117,9 @@ pub trait HetPixel: Copy + 'static {
     /// assert_eq!(rgb.alpha_opt(), None);
     /// assert_eq!(rgba.alpha_opt(), Some(50));
     /// ```
-    #[doc(alias="alpha")]
-    #[doc(alias="try_alpha")]
-    #[doc(alias="alpha_checked")]
+    #[doc(alias = "alpha")]
+    #[doc(alias = "try_alpha")]
+    #[doc(alias = "alpha_checked")]
     fn alpha_opt(&self) -> Option<Self::AlphaComponent>;
     /// Returns a mutable borrow of the pixel's alpha alpha component if it has one.
     ///
@@ -143,7 +143,7 @@ pub trait HetPixel: Copy + 'static {
     /// assert_eq!(rgb.alpha_opt(), None);
     /// assert_eq!(rgba.alpha_opt(), Some(40));
     /// ```
-    #[doc(alias="alpha_checked_mut")]
+    #[doc(alias = "alpha_checked_mut")]
     fn alpha_opt_mut(&mut self) -> Option<&mut Self::AlphaComponent>;
 
     /// Tries to create new instance given an iterator of color components and an alpha component.

--- a/src/pixel_traits/pixel.rs
+++ b/src/pixel_traits/pixel.rs
@@ -29,7 +29,7 @@ pub trait Pixel:
     /// The component type of the pixel used for both color and alpha components if any.
     type Component: Copy + 'static;
 
-    /// An generic associated type used to return the array of
+    /// A generic associated type used to return the array of
     /// components despite rust's lack of const generic expressions.
     ///
     /// Used in functions like [`Pixel::to_array()`].

--- a/src/pixel_traits/pixel.rs
+++ b/src/pixel_traits/pixel.rs
@@ -84,7 +84,7 @@ pub trait Pixel:
     /// # Examples
     ///
     /// ```
-    /// use rgb::{Pixel, Rgb, Rgba, error::TryFromComponentsError};
+    /// use rgb::{Pixel, Rgb, Rgba, TryFromComponentsError};
     ///
     /// let mut values2 = [0_u8, 10];
     /// let mut values4 = [0_u8, 10, 100, 40];


### PR DESCRIPTION
Thanks @kornelski for the all the commits you've added to the `0.9` (now `0.9-old` I think), branch, nearly all of them are amazing changes. I've gone through them all (they're very well organized too!) and compiled some tweaks, mainly doc-related.

The one non-doc change which I think may not be a good idea is moving the `TryFrom` error types into a top-level module `error`. When writing out an import statement I no longer get auto-complete after typing `use rgb::` for those types. So I'd need to start memorizing the name of the module they are in, `error`, which makes typing longer for no benefit I can see at the moment since no other types/traits in the library begin with "T" at the moment.