### PR TITLE
remove legacy feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.63"
 
 [features]
 # Since v0.9 all pixel formats are enabled by default, beacause it has negligible impact on compilation time
-default = ["grb", "argb"]
+default = ["grb", "argb", "as-bytes"]
 
 # Implements some of the traits, see `rgb::num_traits` module for details.
 num-traits = ["dep:num-traits"]
@@ -25,8 +25,6 @@ defmt-03 = ["dep:defmt"]
 serde = ["dep:serde"]
 bytemuck = ["dep:bytemuck"]
 
-# Legacy features to be removed after `v0.10`
-legacy = ["as-bytes"]
 # Deprecated: it's always enabled anyway
 argb = []
 # Deprecated: it's always enabled anyway

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.63"
 
 [features]
-# Since v0.9 all pixel formats are enabled by default, beacause it has negligible impact on compilation time
+# Since all pixel formats are enabled by default, because it has negligible impact on compilation time
 default = ["grb", "argb", "as-bytes"]
 
 # Implements some of the traits, see `rgb::num_traits` module for details.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pixel types for [Rust](https://www.rust-lang.org) [![crate](https://img.shields.io/crates/v/rgb.svg)](https://lib.rs/crates/rgb)
 
-Operating on pixels as weakly-typed vectors of `u8` is error-prone and inconvenient. It's better to use vectors of pixel structs. However, Rust is so strongly typed that _your_ `Rgb` pixel struct is not compatible with _my_ `Rgb` pixel struct. So let's all use mine :P
+Operating on pixels as weakly-typed vectors of `u8` is error-prone and inconvenient. It's better to use vectors of pixel structs.
+However, Rust is so strongly typed that _your_ `Rgb` pixel struct is not compatible with _my_ `Rgb` pixel struct. So let's all use mine :P
 
 [<img src="https://imgs.xkcd.com/comics/standards_2x.png" alt="xkcd: …there are 15 competing standards" width="500">](https://xkcd.com/927/)
 
@@ -23,18 +24,21 @@ We welcome your feedback about the crate!
 
 - Are the names of the traits and their methods good?
 - Are there any standard library traits you'd like implemented on the pixel types?
-- Is the split between `Pixel`, `HetPixel`, `HasAlpha` sensible? (pixels support a different type for the alpha channel, and there's `Rgbw` without alpha).
+- Is the split between `Pixel`, `HetPixel`, `HasAlpha` sensible?
+  (pixels support a different type for the alpha channel, and there's `Rgbw` without alpha).
 
-[Please open issues in the repo with the feedback](https://github.com/kornelski/rust-rgb/issues) or message [@kornel@mastodon.social](https://mastodon.social/@kornel).
+[Please open issues in the repo with the feedback](https://github.com/kornelski/rust-rgb/issues)
+or message [@kornel@mastodon.social](https://mastodon.social/@kornel).
 
 ## Installation
 
-If you want to run a stable, compatible version, run `cargo add rgb@0.8.43`. If you want to try unstable experimental version, run `cargo add rgb@0.8.90-alpha.1` or add this to your `Cargo.toml`:
+If you want to run a stable, compatible version, run `cargo add rgb@0.8.47`.
+If you want to try unstable experimental version, run `cargo add rgb@0.8.90-alpha.1` or add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
 rgb = "0.8.90-alpha.1" # unstable experimental version
-# rgb = "0.8.43" # older, stable
+# rgb = "0.8.47" # older, stable
 ```
 
 ## Usage
@@ -212,9 +216,12 @@ This crate is purposefully agnostic about the color-spaces of the
 pixel types. For example, `Gray<u8>` could be either linear lightness or
 gamma-corrected luma, etc.
 
-_Correct_ color management is a complex problem, and this crate aims to be the lowest common denominator, so it's intentionally agnostic about it.
+_Correct_ color management is a complex problem, and this crate aims
+to be the lowest common denominator, so it's intentionally agnostic
+about it.
 
-However, this library supports any subpixel type for `RGB<T>`, and `RGBA<RGBType, AlphaType>`, so you can use them with a newtype, e.g.:
+However, this library supports any subpixel type for `RGB<T>`, and
+`RGBA<RGBType, AlphaType>`, so you can use them with a newtype, e.g.:
 
 ```rust
 # use rgb::Rgb;
@@ -224,13 +231,21 @@ type LinearRGB = Rgb<LinearLight>;
 
 ## Roadmap to 1.0
 
-The plan is to provide easy migration to v1.0. There will be a transitional v0.9 version released that will be mostly backwards-compatible with 0.8, and forwards-compatible with 1.0.
+The plan is to provide easy migration to v1.0. There will be a
+transitional v0.9 version released that will be mostly
+backwards-compatible with 0.8, and forwards-compatible with 1.0.
 
 Planned changes:
 
-- Types will be renamed to follow Rust's naming convention: `RGBA` → `Rgba`. The names with an `8` or `16` suffix (`RGBA8`) will continue to work.
-- The `Gray` and `GrayAlpha` types will change from tuple structs with `.0` to structs with named fields `.v` (value) and `.a` (alpha). Through a `Deref` trick both field names will work, but `.0` is going to be deprecated.
-- `bytemuck::Pod` (conversions from/to raw bytes) will require color and alpha components to be the same type (i.e. it will work with `Rgba<u8>`, but not `Rgba<Newtype, DifferentType>`). Currently it's unsound if the alpha has a different size than color components.
+- Types will be renamed to follow Rust's naming convention: `RGBA` → `Rgba`.
+  The names with an `8` or `16` suffix (`RGBA8`) will continue to work.
+- The `Gray` and `GrayAlpha` types will change from tuple structs with
+  `.0` to structs with named fields `.v` (value) and `.a` (alpha).
+  Through a `Deref` trick both field names will work, but `.0` is going to be deprecated.
+- `bytemuck::Pod` (conversions from/to raw bytes) will require color
+  and alpha components to be the same type (i.e. it will work with
+  `Rgba<u8>`, but not `Rgba<Newtype, DifferentType>`).
+  Currently it's unsound if the alpha has a different size than color components.
 - Many inherent methods will be moved to a new `Pixel` trait.
 
 ## Migrating away from deprecated items
@@ -241,11 +256,10 @@ may need to do.
 
 1. Update to the latest version of 0.8, and fix all deprecation warnings.
    - rename `.alpha()` to `.with_alpha()`
-2. Change field access on `GrayAlpha` from `.0` and `.1` to `.v` and `.a` where possible.
-3. Use the `bytemuck` crate for conversions from/to bytes.
-4. Use the `num-traits` crate for `.checked_add()`, don't enable `checked_fns` feature.
-5. Don't enable `gbr` and `argb` features. All pixel types are enabled by default.
-6. `AsRef<[T]>` implementations have changed to `AsRef<[T; N]>`. In most cases `.as_ref()`/`.as_mut()` calls should coerce to a slice anyway.
-7. Instead of `pixel.as_slice()` use `pixel.as_ref()`.
-6. Stop using the `rgb::Gray`/`rgb::GrayAlpha` types and switch to
-   `rgb::Gray_v09 as Gray`/`rgb::GrayA` instead respectively.
+1. Change field access on `GrayAlpha` from `.0` and `.1` to `.v` and `.a` where possible.
+1. Use the `bytemuck` crate for conversions from/to bytes.
+1. Use the `num-traits` crate for `.checked_add()`, don't enable `checked_fns` feature.
+1. Don't enable `gbr` and `argb` features. All pixel types are enabled by default.
+1. `AsRef<[T]>` implementations have changed to `AsRef<[T; N]>`. In most cases `.as_ref()`/`.as_mut()` calls should coerce to a slice anyway.
+1. Instead of `pixel.as_slice()` use `pixel.as_ref()`.
+1. Stop using the `rgb::Gray`/`rgb::GrayAlpha` types and switch to `rgb::Gray_v09 as Gray`/`rgb::GrayA` instead respectively.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ For **testing**, use:
 ```toml
 [dependencies]
 rgb = "0.8.90"
-# or: rgb = { version = "0.8.90", features = ["legacy"] }
 
 # this is required, because v0.8.90 is not on crates.io
 [patch.crates-io]
@@ -25,8 +24,6 @@ We welcome your feedback about the crate!
 - Are the names of the traits and their methods good?
 - Are there any standard library traits you'd like implemented on the pixel types?
 - Is the split between `Pixel`, `HetPixel`, `HasAlpha` sensible? (pixels support a different type for the alpha channel, and there's `Rgbw` without alpha).
-- With the `legacy` feature enabled, is the crate sufficiently backwards compatible? (later we're going to use semver trick to provide interoperability with other v0.8 crates)
-- Without the `legacy` feature enabled, is the upgrade easy? Anything missing?
 
 [Please open issues in the repo with the feedback](https://github.com/kornelski/rust-rgb/issues) or message [@kornel@mastodon.social](https://mastodon.social/@kornel).
 
@@ -203,7 +200,6 @@ the `v0.8` release so as to be non-breaking, however, once migrated to
 going to be removed in the next major release after `v0.9`.
 
 ```toml
-legacy = ["as-bytes"]
 argb = []
 grb = []
 checked_fns = []

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ rgb = "0.8.90-alpha.1" # unstable experimental version
 ## Usage
 
 ```rust
-use rgb::{Rgb, Rgba, Argb, Bgr, Bgra, Abgr, Grb, Gray, GrayA};
+use rgb::{Rgb, Rgba, Argb, Bgr, Bgra, Abgr, Grb, Gray_v09 as Gray, GrayA};
 
 let rgb = Rgb {r: 0, g: 0, b: 0};
 let rbga = Rgba {r: 0, g: 0, b: 0, a: 0};
@@ -233,15 +233,19 @@ Planned changes:
 - `bytemuck::Pod` (conversions from/to raw bytes) will require color and alpha components to be the same type (i.e. it will work with `Rgba<u8>`, but not `Rgba<Newtype, DifferentType>`). Currently it's unsound if the alpha has a different size than color components.
 - Many inherent methods will be moved to a new `Pixel` trait.
 
-## Migration from 0.8 to 0.9
+## Migrating away from deprecated items
+
+Many items in this crate have become deprecated in preparation for a
+future release which removes them. Here is a checklist of things you
+may need to do.
 
 1. Update to the latest version of 0.8, and fix all deprecation warnings.
-
    - rename `.alpha()` to `.with_alpha()`
-
 2. Change field access on `GrayAlpha` from `.0` and `.1` to `.v` and `.a` where possible.
 3. Use the `bytemuck` crate for conversions from/to bytes.
 4. Use the `num-traits` crate for `.checked_add()`, don't enable `checked_fns` feature.
 5. Don't enable `gbr` and `argb` features. All pixel types are enabled by default.
 6. `AsRef<[T]>` implementations have changed to `AsRef<[T; N]>`. In most cases `.as_ref()`/`.as_mut()` calls should coerce to a slice anyway.
 7. Instead of `pixel.as_slice()` use `pixel.as_ref()`.
+6. Stop using the `rgb::Gray`/`rgb::GrayAlpha` types and switch to
+   `rgb::Gray_v09 as Gray`/`rgb::GrayA` instead respectively.

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,16 +1,27 @@
-use rgb::{Rgb, Pixel};
-
+#[cfg(feature = "as-bytes")]
 fn main() {
-    use rgb::{ComponentSlice, ComponentBytes};
+    use rgb::{ComponentBytes, ComponentSlice};
+    use rgb::{Pixel, Rgb};
 
-    let px = Rgb{r:255_u8,g:0,b:100};
+    let px = Rgb {
+        r: 255_u8,
+        g: 0,
+        b: 100,
+    };
     assert_eq!([px].as_bytes()[0], 255);
 
-    let bigpx = Rgb::<u16>{r:65535_u16,g:0,b:0};
+    let bigpx = Rgb::<u16> {
+        r: 65535_u16,
+        g: 0,
+        b: 0,
+    };
     assert_eq!(bigpx.as_slice()[0], 65535);
 
     let px = Rgb::<u8>::new(255, 0, 255);
-    let inverted: Rgb::<u8> = px.map(|ch| 255 - ch);
+    let inverted: Rgb<u8> = px.map(|ch| 255 - ch);
 
     println!("{inverted}"); // rgb(0,255,0)
 }
+
+#[cfg(not(feature = "as-bytes"))]
+fn main() {}

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,6 +1,5 @@
 use rgb::{Rgb, Pixel};
 
-#[cfg(feature = "legacy")]
 fn main() {
     use rgb::{ComponentSlice, ComponentBytes};
 
@@ -15,6 +14,3 @@ fn main() {
 
     println!("{inverted}"); // rgb(0,255,0)
 }
-
-#[cfg(not(feature = "legacy"))]
-fn main() {}

--- a/src/bytemuck.rs
+++ b/src/bytemuck.rs
@@ -20,17 +20,13 @@ bytemuck!(Bgra);
 bytemuck!(Abgr);
 bytemuck!(GrayA);
 
-#[cfg(feature = "legacy")]
 use crate::formats::gray_alpha::GrayAlpha_v08;
-#[cfg(feature = "legacy")]
 bytemuck!(GrayAlpha_v08);
 
-#[cfg(feature = "legacy")]
 use crate::formats::gray::Gray_v08;
-#[cfg(feature = "legacy")]
 bytemuck!(Gray_v08);
 
-#[cfg(all(feature = "legacy", feature = "as-bytes"))]
+#[cfg(feature = "as-bytes")]
 impl<T: ::bytemuck::Pod> crate::ComponentBytes<T> for [Gray<T>] {
     #[inline]
     fn as_bytes(&self) -> &[u8] {
@@ -45,7 +41,7 @@ impl<T: ::bytemuck::Pod> crate::ComponentBytes<T> for [Gray<T>] {
     }
 }
 
-#[cfg(all(feature = "legacy", feature = "as-bytes"))]
+#[cfg(feature = "as-bytes")]
 impl<T: ::bytemuck::Pod> crate::ComponentBytes<T> for [GrayAlpha_v08<T>] {
     #[inline]
     fn as_bytes(&self) -> &[u8] {

--- a/src/bytemuck.rs
+++ b/src/bytemuck.rs
@@ -1,4 +1,4 @@
-use crate::{Abgr, Argb, Bgr, Bgra, Gray, GrayA, Grb, Rgb, Rgba, Rgbw};
+use crate::{Abgr, Argb, Bgr, Bgra, Gray_v09, GrayA, Grb, Rgb, Rgba, Rgbw};
 
 pub use ::bytemuck::*;
 
@@ -12,7 +12,7 @@ macro_rules! bytemuck {
 bytemuck!(Rgb);
 bytemuck!(Bgr);
 bytemuck!(Grb);
-bytemuck!(Gray);
+bytemuck!(Gray_v09);
 bytemuck!(Rgbw);
 bytemuck!(Rgba);
 bytemuck!(Argb);
@@ -27,7 +27,7 @@ use crate::formats::gray::Gray_v08;
 bytemuck!(Gray_v08);
 
 #[cfg(feature = "as-bytes")]
-impl<T: ::bytemuck::Pod> crate::ComponentBytes<T> for [Gray<T>] {
+impl<T: ::bytemuck::Pod> crate::ComponentBytes<T> for [Gray_v08<T>] {
     #[inline]
     fn as_bytes(&self) -> &[u8] {
         assert_ne!(0, core::mem::size_of::<T>());

--- a/src/core_traits.rs
+++ b/src/core_traits.rs
@@ -1,5 +1,4 @@
-
-use crate::{Abgr, Argb, Bgr, Bgra, Grb, Gray_v09, GrayA, Rgb, Rgba, Rgbw};
+use crate::{Abgr, Argb, Bgr, Bgra, GrayA, Gray_v09, Grb, Rgb, Rgba, Rgbw};
 use core::array::TryFromSliceError;
 use core::fmt;
 use core::iter::Sum;

--- a/src/core_traits.rs
+++ b/src/core_traits.rs
@@ -1,5 +1,5 @@
 
-use crate::{Abgr, Argb, Bgr, Bgra, Grb, Gray, GrayA, Rgb, Rgba, Rgbw};
+use crate::{Abgr, Argb, Bgr, Bgra, Grb, Gray_v09, GrayA, Rgb, Rgba, Rgbw};
 use core::array::TryFromSliceError;
 use core::fmt;
 use core::iter::Sum;
@@ -454,7 +454,7 @@ macro_rules! trait_impls_without_alpha {
 trait_impls_without_alpha!(Rgb, 3, [r, g, b], "rgb({}, {}, {})", "rgb(#{:0w$X}{:0w$X}{:0w$X})", "rgb(#{:0w$x}{:0w$x}{:0w$x})");
 trait_impls_without_alpha!(Bgr, 3, [b, g, r], "bgr({}, {}, {})", "bgr(#{:0w$X}{:0w$X}{:0w$X})", "bgr(#{:0w$x}{:0w$x}{:0w$x})");
 trait_impls_without_alpha!(Grb, 3, [g, r, b], "grb({}, {}, {})", "grb(#{:0w$X}{:0w$X}{:0w$X})", "grb(#{:0w$x}{:0w$x}{:0w$x})");
-trait_impls_without_alpha!(Gray, 1, [v], "gray({})", "gray(#{:0w$X})", "gray(#{:0w$x})");
+trait_impls_without_alpha!(Gray_v09, 1, [v], "gray({})", "gray(#{:0w$X})", "gray(#{:0w$x})");
 trait_impls_without_alpha!(Rgbw, 4, [r, g, b, w], "rgbw({}, {}, {}, {})", "rgbw(#{:0w$X}{:0w$X}{:0w$X}{:0w$X})", "rgbw(#{:0w$x}{:0w$x}{:0w$x}{:0w$x})");
 
 use crate::formats::gray::Gray_v08;

--- a/src/core_traits.rs
+++ b/src/core_traits.rs
@@ -457,9 +457,7 @@ trait_impls_without_alpha!(Grb, 3, [g, r, b], "grb({}, {}, {})", "grb(#{:0w$X}{:
 trait_impls_without_alpha!(Gray, 1, [v], "gray({})", "gray(#{:0w$X})", "gray(#{:0w$x})");
 trait_impls_without_alpha!(Rgbw, 4, [r, g, b, w], "rgbw({}, {}, {}, {})", "rgbw(#{:0w$X}{:0w$X}{:0w$X}{:0w$X})", "rgbw(#{:0w$x}{:0w$x}{:0w$x}{:0w$x})");
 
-#[cfg(feature = "legacy")]
 use crate::formats::gray::Gray_v08;
-#[cfg(feature = "legacy")]
 trait_impls_without_alpha!(Gray_v08, 1, [0], "gray_v0.8({})", "gray_v0.8(#{:0w$X})", "gray_v0.8(#{:0w$x})");
 
 trait_impls_with_alpha!(Rgba, 4, [r, g, b, a], "rgba({}, {}, {}, {})", "rgba(#{:0w$X}{:0w$X}{:0w$X}{:0w$X})", "rgba(#{:0w$x}{:0w$x}{:0w$x}{:0w$x})");
@@ -468,9 +466,7 @@ trait_impls_with_alpha!(Bgra, 4, [b, g, r, a], "bgra({}, {}, {}, {})", "bgra(#{:
 trait_impls_with_alpha!(Abgr, 4, [a, b, g, r], "abgr({}, {}, {}, {})", "abgr(#{:0w$X}{:0w$X}{:0w$X}{:0w$X})", "abgr(#{:0w$x}{:0w$x}{:0w$x}{:0w$x})");
 trait_impls_with_alpha!(GrayA, 2, [v, a], "graya({}, {})", "graya(#{:0w$X}{:0w$X})", "graya(#{:0w$x}{:0w$x})");
 
-#[cfg(feature = "legacy")]
 use crate::formats::gray_alpha::GrayAlpha_v08;
-#[cfg(feature = "legacy")]
 trait_impls_with_alpha!(GrayAlpha_v08, 2, [0, 1], "graya_v0.8({}, {})", "graya_v0.8(#{:0w$X}{:0w$X})", "graya_v0.8(#{:0w$x}{:0w$x})");
 
 

--- a/src/formats/gray.rs
+++ b/src/formats/gray.rs
@@ -2,19 +2,28 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-/// A `Grayscale` pixel (rgb crate v0.8)
+/// A `Grayscale` pixel
+///
+/// This is the legacy gray pixel type as opposed to the new gray type
+/// (`rgb::Gray_v09`). This type is kept for backwards-compatibility.
+///
+/// You should transition to the new gray pixel type as this type is
+/// due to be removed in a future release.
 #[allow(non_camel_case_types)]
 pub struct Gray_v08<T>(
     /// Grayscale Component. This field will be renamed to `v`.
     pub T,
 );
 
-/// A `Grayscale` pixel (rgb crate v0.9)
+/// A `Grayscale` pixel.
+///
+/// This is the new gray pixel type as opposed to the legacy gray type
+/// (`rgb::Gray`) which is kept for backwards-compatibility.
 ///
 /// # Examples
 ///
 /// ```
-/// use rgb::Gray;
+/// use rgb::Gray_v09 as Gray;
 ///
 /// let pixel: Gray<u8> = Gray { v: 0 };
 /// ```

--- a/src/formats/gray_a.rs
+++ b/src/formats/gray_a.rs
@@ -8,6 +8,9 @@
 /// grayscale images can also be represented using `GrayA<u8, bool>`,
 /// but this won't reduce the storage size.
 ///
+/// This is the new gray+alpha pixel type as opposed to the legacy gray+alpha type
+/// (`rgb::GrayAlpha`) which is kept for backwards-compatibility.
+///
 /// # Examples
 ///
 /// ```

--- a/src/formats/gray_alpha.rs
+++ b/src/formats/gray_alpha.rs
@@ -7,6 +7,12 @@ use core::ops::Deref;
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A pixel for grayscale value + alpha components (rgb crate v0.8)
 ///
+/// This is the legacy gray+alpha pixel type as opposed to the new gray+alpha type
+/// (`rgb::GrayA`). This type is kept for backwards-compatibility.
+///
+/// You should transition to the new gray+alpha pixel type as this type is
+/// due to be removed in a future release.
+///
 /// Through a `Deref` hack it renames the fields from `.0` and `.1`
 /// to `.v` (value) and `.a` (alpha)
 #[allow(non_camel_case_types)]

--- a/src/from.rs
+++ b/src/from.rs
@@ -1,4 +1,4 @@
-use crate::{Abgr, Argb, Bgr, Bgra, Gray, GrayA, Grb, Rgb, Rgba};
+use crate::{Abgr, Argb, Bgr, Bgra, Gray_v09, GrayA, Grb, Rgb, Rgba};
 
 macro_rules! without_alpha {
     ($from_type:ident, $self_type:ident, {$($bit:tt),*}) => {
@@ -68,4 +68,4 @@ with_alpha!(Rgba, Abgr, {r, g, b, a});
 with_alpha!(Argb, Abgr, {r, g, b, a});
 with_alpha!(Bgra, Abgr, {r, g, b, a});
 
-alpha_to_no_alpha!(GrayA, Gray, { v });
+alpha_to_no_alpha!(GrayA, Gray_v09, { v });

--- a/src/inherent_impls.rs
+++ b/src/inherent_impls.rs
@@ -1,4 +1,4 @@
-use crate::{Abgr, Argb, Bgr, Bgra, Gray, GrayA, Grb, Rgb, Rgba, Rgbw};
+use crate::{Abgr, Argb, Bgr, Bgra, Gray_v09, GrayA, Grb, Rgb, Rgba, Rgbw};
 
 macro_rules! inherent_impls {
     ($name:ident, $new_fn:ident, [$($field:tt $var:ident),*]) => {
@@ -22,7 +22,7 @@ macro_rules! inherent_impls {
 inherent_impls!(Rgb, new, [r red, g green, b blue]);
 inherent_impls!(Bgr, new_bgr, [b blue, g green, r red]);
 inherent_impls!(Grb, new_grb, [g green, r red, b blue]);
-inherent_impls!(Gray, new, [v value]);
+inherent_impls!(Gray_v09, new, [v value]);
 inherent_impls!(Rgbw, new, [r red, g green, b blue, w white]);
 
 use crate::formats::gray::Gray_v08;

--- a/src/inherent_impls.rs
+++ b/src/inherent_impls.rs
@@ -25,9 +25,7 @@ inherent_impls!(Grb, new_grb, [g green, r red, b blue]);
 inherent_impls!(Gray, new, [v value]);
 inherent_impls!(Rgbw, new, [r red, g green, b blue, w white]);
 
-#[cfg(feature = "legacy")]
 use crate::formats::gray::Gray_v08;
-#[cfg(feature = "legacy")]
 inherent_impls!(Gray_v08, new, [0 value]);
 
 inherent_impls!(Rgba, new, [r red, g green, b blue, a alpha]);
@@ -36,7 +34,5 @@ inherent_impls!(Bgra, new_bgra, [b blue, g green, r red, a alpha]);
 inherent_impls!(Abgr, new_abgr, [a alpha, b blue, g green, r red]);
 inherent_impls!(GrayA, new, [v value, a alpha]);
 
-#[cfg(feature = "legacy")]
 use crate::formats::gray_alpha::GrayAlpha_v08;
-#[cfg(feature = "legacy")]
 inherent_impls!(GrayAlpha_v08, new, [0 value, 1 alpha]);

--- a/src/legacy/internal/convert/mod.rs
+++ b/src/legacy/internal/convert/mod.rs
@@ -1,8 +1,8 @@
 use crate::alt::*;
+use crate::formats::gray::Gray_v08;
+use crate::pixel_traits::pixel::Pixel;
 use crate::*;
 use core::{mem, slice};
-use crate::pixel_traits::pixel::Pixel;
-use crate::formats::gray::Gray_v08;
 
 /// Casts a slice of bytes into a slice of pixels, e.g. `[u8]` to `[RGB8]`.
 ///

--- a/src/legacy/internal/ops.rs
+++ b/src/legacy/internal/ops.rs
@@ -1,7 +1,11 @@
+#[allow(unused_imports)]
 use crate::formats::gray::Gray_v08;
+#[allow(unused_imports)]
 use crate::formats::gray_alpha::GrayAlpha_v08;
+#[allow(unused_imports)]
 use crate::{Abgr, Argb, Bgr, Bgra, Grb,Rgb, Rgba};
 
+#[allow(unused_macros)]
 macro_rules! impl_struct_checked {
     ($ty:ident, $field_ty:ident, => $($field:tt)+) => {
         impl $ty<$field_ty>
@@ -31,6 +35,7 @@ macro_rules! impl_struct_checked {
     }
 }
 
+#[allow(unused_macros)]
 macro_rules! impl_legacy_checked {
     ($ty:ident => $($field:tt)+) => {
         impl_struct_checked!($ty, u8, => $($field)+);

--- a/src/legacy/internal/ops.rs
+++ b/src/legacy/internal/ops.rs
@@ -3,7 +3,7 @@ use crate::formats::gray::Gray_v08;
 #[allow(unused_imports)]
 use crate::formats::gray_alpha::GrayAlpha_v08;
 #[allow(unused_imports)]
-use crate::{Abgr, Argb, Bgr, Bgra, Grb,Rgb, Rgba};
+use crate::{Abgr, Argb, Bgr, Bgra, Grb, Rgb, Rgba};
 
 #[allow(unused_macros)]
 macro_rules! impl_struct_checked {
@@ -98,12 +98,12 @@ mod test {
         assert_eq!(RGBA::new_alpha(2f32,4.,6.,8u32), RGBA::new_alpha(1f32,2.,3.,4u32) + RGBA{r:1f32,g:2.0,b:3.0,a:4u32});
         assert_eq!(RGBA::new(2i16,4,6,8), RGBA::new(1,3,5,7) + 1);
 
-        assert_eq!(RGB::new(255, 255, 0), RED_RGB+GREEN_RGB);
-        assert_eq!(RGB::new(255, 0, 0), RED_RGB+RGB::new(0, 0, 0));
+        assert_eq!(RGB::new(255, 255, 0), RED_RGB + GREEN_RGB);
+        assert_eq!(RGB::new(255, 0, 0), RED_RGB + RGB::new(0, 0, 0));
         assert_eq!(WHITE_RGB, BLACK_RGB + 255);
 
-        assert_eq!(RGBA::new(255, 255, 0, 255), RED_RGBA+GREEN_RGBA);
-        assert_eq!(RGBA::new(255, 0, 0, 255), RED_RGBA+RGBA::new(0, 0, 0, 0));
+        assert_eq!(RGBA::new(255, 255, 0, 255), RED_RGBA + GREEN_RGBA);
+        assert_eq!(RGBA::new(255, 0, 0, 255), RED_RGBA + RGBA::new(0, 0, 0, 0));
         assert_eq!(WHITE_RGBA, BLACK_RGBA + 255);
     }
 

--- a/src/legacy/internal/pixel.rs
+++ b/src/legacy/internal/pixel.rs
@@ -68,7 +68,7 @@ fn shared_impl() {
     }
 
     let b = SharedPixelBuffer {
-        data: [crate::RGB8::new(0,0,0)],
+        data: [crate::RGB8::new(0, 0, 0)],
     };
     let _ = b.as_bytes();
 }

--- a/src/legacy/internal/rgba.rs
+++ b/src/legacy/internal/rgba.rs
@@ -395,7 +395,7 @@ fn bgra_test() {
     assert_eq!(neg.b, -3);
     assert_eq!(neg.bgr().b, -3);
     assert_eq!(neg.a, -1000);
-    assert_eq!(&[-3,-2,-1,-1000], neg.as_slice());
+    assert_eq!(&[-3, -2, -1, -1000], neg.as_slice());
     assert!(neg < BGRA::new(0, 0, 0, 0));
 
     let neg = BGRA::new(1u8, 2u8, 3u8, 4u8).map_rgb(|c| -(c as i16));
@@ -413,10 +413,9 @@ fn bgra_test() {
     assert_eq!(4, px.bgr_mut().b);
     assert_eq!(100, px.a);
 
-
     #[cfg(feature = "as-bytes")]
     {
         let v = vec![BGRA::new(3u8, 2, 1, 4), BGRA::new(7, 6, 5, 8)];
-        assert_eq!(&[1,2,3,4,5,6,7,8], v.as_bytes());
+        assert_eq!(&[1, 2, 3, 4, 5, 6, 7, 8], v.as_bytes());
     }
 }

--- a/src/legacy/mod.rs
+++ b/src/legacy/mod.rs
@@ -51,7 +51,7 @@ fn rgb_works() {
         assert_eq!(0xFF, [rgb].as_bytes()[5]);
     }
 
-    assert_eq!("rgb(1, 2, 3)", format!("{}", RGB::new(1,2,3)));
+    assert_eq!("rgb(1, 2, 3)", format!("{}", RGB::new(1, 2, 3)));
 }
 
 #[test]
@@ -63,10 +63,10 @@ fn sub_floats() {
 #[test]
 #[allow(deprecated)]
 fn into() {
-    let a:crate::RGB8 = crate::Rgb{r:0,g:1,b:2};
-    let b:RGB<i16> = a.into();
-    let c:RGB<f32> = b.into();
-    let d:RGB<f32> = a.into();
+    let a: crate::RGB8 = crate::Rgb { r: 0, g: 1, b: 2 };
+    let b: RGB<i16> = a.into();
+    let c: RGB<f32> = b.into();
+    let d: RGB<f32> = a.into();
     assert_eq!(c, d);
 }
 
@@ -79,9 +79,9 @@ fn rgba_works() {
 
     assert_eq!(rgba, rgba.iter().map(|ch| ch).collect());
 
-    assert_eq!("rgba(1, 2, 3, 4)", format!("{}", RGBA::new(1,2,3,4)));
+    assert_eq!("rgba(1, 2, 3, 4)", format!("{}", RGBA::new(1, 2, 3, 4)));
 
-    assert_eq!(rgba - rgba, RGBA::new(0,0,0,0));
+    assert_eq!(rgba - rgba, RGBA::new(0, 0, 0, 0));
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
 
-#[cfg(all(test, feature = "legacy"))]
 #[macro_use]
 extern crate std;
 
@@ -15,7 +14,6 @@ mod formats {
     pub mod bgra;
     pub mod gray;
     pub mod gray_a;
-    #[cfg(feature = "legacy")]
     pub mod gray_alpha;
     pub mod grb;
     pub mod rgb;
@@ -44,17 +42,11 @@ mod pixel_traits {
 #[doc(alias = "Pod")]
 pub mod bytemuck;
 
-#[cfg(feature = "legacy")]
 mod legacy;
-#[cfg(feature = "legacy")]
 pub use ::bytemuck::{Pod, Zeroable};
-#[cfg(feature = "legacy")]
 pub use legacy::internal::convert::{AsPixels, FromSlice};
-#[cfg(feature = "legacy")]
 pub use legacy::internal::pixel::{ColorComponentMap, ComponentBytes, ComponentSlice};
-#[cfg(feature = "legacy")]
 pub use legacy::*;
-#[cfg(feature = "legacy")]
 pub use pixel_traits::pixel::Pixel as ComponentMap;
 
 /// If the `num-traits` feature is enabled, the implemented traits are in this module

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,9 @@ mod legacy;
 #[cfg(feature = "bytemuck")]
 pub use ::bytemuck::{Pod, Zeroable};
 pub use legacy::internal::convert::{AsPixels, FromSlice};
-pub use legacy::internal::pixel::{ColorComponentMap, ComponentSlice};
 #[cfg(feature = "bytemuck")]
 pub use legacy::internal::pixel::ComponentBytes;
+pub use legacy::internal::pixel::{ColorComponentMap, ComponentSlice};
 pub use legacy::*;
 pub use pixel_traits::pixel::Pixel as ComponentMap;
 
@@ -60,8 +60,10 @@ pub use formats::abgr::Abgr;
 pub use formats::argb::Argb;
 pub use formats::bgr::Bgr;
 pub use formats::bgra::Bgra;
-pub use formats::gray::Gray_v09 as Gray;
+pub use formats::gray::Gray_v08 as Gray;
+pub use formats::gray::Gray_v09;
 pub use formats::gray_a::GrayA;
+pub use formats::gray_alpha::GrayAlpha_v08 as GrayAlpha;
 pub use formats::grb::Grb;
 pub use formats::rgb::Rgb;
 pub use formats::rgba::Rgba;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,12 @@ mod pixel_traits {
 pub mod bytemuck;
 
 mod legacy;
+#[cfg(feature = "bytemuck")]
 pub use ::bytemuck::{Pod, Zeroable};
 pub use legacy::internal::convert::{AsPixels, FromSlice};
-pub use legacy::internal::pixel::{ColorComponentMap, ComponentBytes, ComponentSlice};
+pub use legacy::internal::pixel::{ColorComponentMap, ComponentSlice};
+#[cfg(feature = "bytemuck")]
+pub use legacy::internal::pixel::ComponentBytes;
 pub use legacy::*;
 pub use pixel_traits::pixel::Pixel as ComponentMap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ mod legacy;
 #[cfg(feature = "bytemuck")]
 pub use ::bytemuck::{Pod, Zeroable};
 pub use legacy::internal::convert::{AsPixels, FromSlice};
-#[cfg(feature = "bytemuck")]
+#[cfg(feature = "as-bytes")]
 pub use legacy::internal::pixel::ComponentBytes;
 pub use legacy::internal::pixel::{ColorComponentMap, ComponentSlice};
 pub use legacy::*;

--- a/src/num_traits.rs
+++ b/src/num_traits.rs
@@ -1,4 +1,4 @@
-use crate::{Abgr, Argb, Bgr, Bgra, Gray, GrayA, Grb, Rgb, Rgba, Rgbw};
+use crate::{Abgr, Argb, Bgr, Bgra, Gray_v09, GrayA, Grb, Rgb, Rgba, Rgbw};
 
 /// Re-exports from [the `num-traits` crate](https://lib.rs/crates/num-traits).
 pub use num_traits::ops::checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
@@ -102,7 +102,7 @@ macro_rules! num_traits_with_alpha {
 num_traits_without_alpha!(Rgb, [r, g, b]);
 num_traits_without_alpha!(Bgr, [b, g, r]);
 num_traits_without_alpha!(Grb, [g, r, b]);
-num_traits_without_alpha!(Gray, [v]);
+num_traits_without_alpha!(Gray_v09, [v]);
 num_traits_without_alpha!(Rgbw, [r, g, b, w]);
 
 num_traits_with_alpha!(Rgba, [r, g, b, a]);

--- a/src/num_traits.rs
+++ b/src/num_traits.rs
@@ -111,7 +111,6 @@ num_traits_with_alpha!(Bgra, [b, g, r, a]);
 num_traits_with_alpha!(Abgr, [a, b, g, r]);
 num_traits_with_alpha!(GrayA, [v, a]);
 
-
 #[test]
 #[cfg(not(feature = "checked_fns"))]
 fn test_checked_sub() {

--- a/src/pixel_traits/gain_alpha.rs
+++ b/src/pixel_traits/gain_alpha.rs
@@ -8,7 +8,7 @@ use crate::{Abgr, Argb, Bgr, Bgra, Gray, GrayA, Rgb, Rgba};
 /// already have an alpha component.
 pub trait GainAlpha: HetPixel {
     /// The pixel type after gaining an alpha component.
-    /// 
+    ///
     /// For example, for `Rgb`: `GainAlpha = Rgba`.
     type GainAlpha: HasAlpha;
 

--- a/src/pixel_traits/has_alpha.rs
+++ b/src/pixel_traits/has_alpha.rs
@@ -72,7 +72,5 @@ has_alpha!(Bgra, a);
 has_alpha!(Abgr, a);
 has_alpha!(GrayA, a);
 
-#[cfg(feature = "legacy")]
 use crate::formats::gray_alpha::GrayAlpha_v08;
-#[cfg(feature = "legacy")]
 has_alpha!(GrayAlpha_v08, 1);

--- a/src/pixel_traits/het_pixel.rs
+++ b/src/pixel_traits/het_pixel.rs
@@ -403,9 +403,7 @@ with_alpha!(Argb, 4, [r, g, b], a);
 with_alpha!(Bgra, 4, [b, g, r], a);
 with_alpha!(GrayA, 2, [v], a);
 
-#[cfg(feature = "legacy")]
 use crate::formats::gray_alpha::GrayAlpha_v08;
-#[cfg(feature = "legacy")]
 with_alpha!(GrayAlpha_v08, 2, [0], 1);
 
 without_alpha!(Bgr, 3, [b, g, r]);
@@ -414,7 +412,5 @@ without_alpha!(Grb, 3, [r, g, b]);
 without_alpha!(Gray, 1, [v]);
 without_alpha!(Rgbw, 4, [r, g, b, w]);
 
-#[cfg(feature = "legacy")]
 use crate::formats::gray::Gray_v08;
-#[cfg(feature = "legacy")]
 without_alpha!(Gray_v08, 1, [0]);

--- a/src/pixel_traits/het_pixel.rs
+++ b/src/pixel_traits/het_pixel.rs
@@ -1,4 +1,4 @@
-use crate::{Abgr, Argb, ArrayLike, Bgr, Bgra, Gray, GrayA, Grb, Rgb, Rgba, Rgbw};
+use crate::{Abgr, Argb, ArrayLike, Bgr, Bgra, GrayA, Gray_v09, Grb, Rgb, Rgba, Rgbw};
 use core::fmt::Display;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -409,7 +409,7 @@ with_alpha!(GrayAlpha_v08, 2, [0], 1);
 without_alpha!(Bgr, 3, [b, g, r]);
 without_alpha!(Rgb, 3, [r, g, b]);
 without_alpha!(Grb, 3, [r, g, b]);
-without_alpha!(Gray, 1, [v]);
+without_alpha!(Gray_v09, 1, [v]);
 without_alpha!(Rgbw, 4, [r, g, b, w]);
 
 use crate::formats::gray::Gray_v08;

--- a/src/pixel_traits/pixel.rs
+++ b/src/pixel_traits/pixel.rs
@@ -261,14 +261,10 @@ without_alpha!(Grb, 3, [r, g, b]);
 without_alpha!(Gray, 1, [v]);
 without_alpha!(Rgbw, 4, [r, g, b, w]);
 
-#[cfg(feature = "legacy")]
 use crate::formats::gray::Gray_v08;
-#[cfg(feature = "legacy")]
 without_alpha!(Gray_v08, 1, [0]);
 
-#[cfg(feature = "legacy")]
 use crate::formats::gray_alpha::GrayAlpha_v08;
-#[cfg(feature = "legacy")]
 with_alpha!(GrayAlpha_v08, 2, [0, 1]);
 
 

--- a/src/pixel_traits/pixel.rs
+++ b/src/pixel_traits/pixel.rs
@@ -1,6 +1,6 @@
 use core::fmt::Display;
 use crate::HetPixel;
-use crate::{Abgr, Argb, ArrayLike, Bgr, Bgra, Gray, GrayA, Grb,Rgb, Rgba, Rgbw};
+use crate::{Abgr, Argb, ArrayLike, Bgr, Bgra, Gray_v09, GrayA, Grb,Rgb, Rgba, Rgbw};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Error returned from the [`Pixel::try_from_components()`] function.
@@ -258,7 +258,7 @@ with_alpha!(GrayA, 2, [v, a]);
 without_alpha!(Bgr, 3, [b, g, r]);
 without_alpha!(Rgb, 3, [r, g, b]);
 without_alpha!(Grb, 3, [r, g, b]);
-without_alpha!(Gray, 1, [v]);
+without_alpha!(Gray_v09, 1, [v]);
 without_alpha!(Rgbw, 4, [r, g, b, w]);
 
 use crate::formats::gray::Gray_v08;

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -1,8 +1,6 @@
 
 use crate::formats::gray::Gray_v09;
-#[cfg(feature = "legacy")]
 use crate::formats::gray::Gray_v08;
-#[cfg(feature = "legacy")]
 use crate::formats::gray_alpha::GrayAlpha_v08;
 use crate::{Abgr, Argb, Bgr, Bgra, Grb, GrayA, Rgb, Rgba, Rgbw};
 
@@ -74,7 +72,6 @@ tuple_conversion!(Rgb, 3, [r:0, g:1, b:2]);
 tuple_conversion!(Bgr, 3, [b:0, g:1, r:2]);
 tuple_conversion!(Grb, 3, [g:0, r:1, b:2]);
 tuple_conversion!(Gray_v09, 1, [v:0]);
-#[cfg(feature = "legacy")]
 tuple_conversion!(Gray_v08, 1, [0:0]);
 tuple_conversion!(Rgbw, 4, [r:0, g:1, b:2, w:3]);
 
@@ -83,5 +80,4 @@ tuple_conversion!(Argb, 4, [a:0, r:1, g:2, b:3]);
 tuple_conversion!(Bgra, 4, [b:0, g:1, r:2, a:3]);
 tuple_conversion!(Abgr, 4, [a:0, b:1, g:2, r:3]);
 tuple_conversion!(GrayA, 2, [v:0, a:1]);
-#[cfg(feature = "legacy")]
 tuple_conversion!(GrayAlpha_v08, 2, [0:0, 1:1]);

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -1,6 +1,5 @@
-
-use crate::formats::gray::Gray_v09;
 use crate::formats::gray::Gray_v08;
+use crate::formats::gray::Gray_v09;
 use crate::formats::gray_alpha::GrayAlpha_v08;
 use crate::{Abgr, Argb, Bgr, Bgra, Grb, GrayA, Rgb, Rgba, Rgbw};
 
@@ -66,7 +65,6 @@ macro_rules! tuple_conversion {
         }
     };
 }
-
 
 tuple_conversion!(Rgb, 3, [r:0, g:1, b:2]);
 tuple_conversion!(Bgr, 3, [b:0, g:1, r:2]);


### PR DESCRIPTION
Now this branch *should* be completely backwards compatible with the current `v0.8` branch.

It would be nice if cargo had the ability to force all dependencies to use a custom version of a dependency which would let us test this manually on popular crates without making an actual release.