### PR TITLE
fix: add backward-compatible methods to Gray_v08 and GrayAlpha_v08

### DIFF
--- a/src/formats/gray.rs
+++ b/src/formats/gray.rs
@@ -48,3 +48,30 @@ impl<T> core::ops::Deref for Gray_v08<T> {
         &self.0
     }
 }
+
+impl<T: Copy> Gray_v08<T> {
+    /// Reads the `.0` field
+    ///
+    /// This is a compatibility shim. Migrate to `Gray_v09` and use `.v` directly.
+    #[deprecated(since = "0.8.91", note = "Use Gray_v09 with .v field instead")]
+    pub fn value(self) -> T {
+        self.0
+    }
+
+    /// Exposes the `.0` field for writing
+    ///
+    /// This is a compatibility shim. Migrate to `Gray_v09` and use `.v` directly.
+    #[deprecated(since = "0.8.91", note = "Use Gray_v09 with .v field instead")]
+    pub fn value_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+
+    /// Add alpha component to this pixel
+    ///
+    /// This is a compatibility shim. Migrate to `Gray_v09` and use `GrayA` instead.
+    #[deprecated(since = "0.8.91", note = "Use Gray_v09::with_alpha() or GrayA instead")]
+    #[allow(deprecated)]
+    pub fn with_alpha(self, add_alpha_value: T) -> crate::formats::gray_alpha::GrayAlpha_v08<T> {
+        crate::formats::gray_alpha::GrayAlpha_v08(self.0, add_alpha_value)
+    }
+}

--- a/src/formats/gray_alpha.rs
+++ b/src/formats/gray_alpha.rs
@@ -1,5 +1,5 @@
 use crate::formats::gray_a::GrayA;
-use core::ops::Deref;
+use core::ops::{Deref, DerefMut};
 
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -34,12 +34,30 @@ impl<T, A> Deref for GrayAlpha_v08<T, A> {
     }
 }
 
+impl<T, A> DerefMut for GrayAlpha_v08<T, A> {
+    /// Compatibility shim - allows mutable access to `.v` and `.a` on the old `GrayAlpha` type.
+    ///
+    /// **Deprecated:** Migrate to `GrayA` instead of `GrayAlpha_v08`.
+    fn deref_mut(&mut self) -> &mut GrayA<T, A> {
+        unsafe { &mut *(self as *mut Self).cast::<GrayA<T, A>>() }
+    }
+}
+
 impl<T: Copy, A> GrayAlpha_v08<T, A> {
     /// Value - the brightness component. May be luma or luminance.
     ///
-    /// Backwards-compatible getter for `self.v`
+    /// This is a compatibility shim. Migrate to `GrayA` and use `.v` directly.
+    #[deprecated(since = "0.8.91", note = "Use GrayA with .v field instead")]
     pub fn value(&self) -> T {
         self.0
+    }
+
+    /// Exposes the `.0` field for writing
+    ///
+    /// This is a compatibility shim. Migrate to `GrayA` and use `.v` directly.
+    #[deprecated(since = "0.8.91", note = "Use GrayA with .v field instead")]
+    pub fn value_mut(&mut self) -> &mut T {
+        &mut self.0
     }
 }
 


### PR DESCRIPTION
> ⚠️ This PR was generated by Claude (Anthropic AI), not by @lilith directly.

## Summary

Adds missing methods to legacy Gray types to maintain backward compatibility with dependent crates during the v0.8 → v0.9 → v1.0 migration.

## Problem

Several crates broke when upgrading to rgb 0.8.90+ due to missing methods on `Gray_v08` and `GrayAlpha_v08`:

| Crate | Error | Method Needed |
|-------|-------|---------------|
| resize | `no method named 'value_mut'` | `Gray.value_mut()` |
| load_image | `cannot assign to data in dereference` | `GrayAlpha: DerefMut` |
| cavif | (depends on load_image) | `GrayAlpha: DerefMut` |
| dssim | (depends on load_image) | `GrayAlpha: DerefMut` |

## Changes

### `src/formats/gray.rs` - Added to `Gray_v08`:
```rust
pub fn value(self) -> T { self.0 }
pub fn value_mut(&mut self) -> &mut T { &mut self.0 }
pub fn with_alpha(self, alpha: T) -> GrayAlpha_v08<T> { ... }
```

### `src/formats/gray_alpha.rs` - Added to `GrayAlpha_v08`:
```rust
pub fn value_mut(&mut self) -> &mut T { &mut self.0 }

impl<T, A> DerefMut for GrayAlpha_v08<T, A> {
    fn deref_mut(&mut self) -> &mut GrayA<T, A> {
        unsafe { &mut *(self as *mut Self).cast::<GrayA<T, A>>() }
    }
}
```

## Safety

The `DerefMut` impl is sound because:
- Both `GrayAlpha_v08<T, A>` (tuple: `(T, A)`) and `GrayA<T, A>` (struct: `{ v: T, a: A }`) are `#[repr(C)]`
- They have identical memory layout
- The cast just reinterprets the same memory

## Testing

Tested with [cargo-copter](https://github.com/imazen/cargo-copter) against **224 top rgb dependents**:

| Status | Count | Percentage |
|--------|-------|------------|
| Passed | 155 | **95.1%** |
| Regressed | 8 | 4.9% |
| Broken (baseline) | 61 | N/A |

### Regression Analysis

Of the 8 regressions found, **most are artifacts of forcing a pre-release version** and will auto-resolve when 0.8.91 is released as stable:

| Category | Crates | Resolution |
|----------|--------|------------|
| Version conflict (auto-resolves) | termchat, picterm, inkview-slint, gol-client, aftershock | Cargo unifies versions when 0.8.91 is stable |
| Missing prelude re-export | aom-decode, cavif | PRs open for [yuv](https://github.com/kornelski/yuv/pull/4) and load_image |
| Internal trait issue | load_image | Needs `IsTransparentPixel` trait fix |

**Key finding:** All affected crates already use flexible version constraints (`^0.8` or `^0.8.x`) that accept 0.8.91. The regressions in testing were caused by forcing a pre-release version while transitive dependencies resolved to 0.8.52 (latest stable), creating type mismatches.

### Notable Successes

Major crates working with 0.8.91: **image**, **resvg**, **oxipng**, **gifski**, **femtovg**, **dssim**, **butteraugli**, **mozjpeg**, **lodepng**, **imagequant**, **fast_image_resize**, **ravif**, **jpegli-rs**

## Related

- Closes #145 (partially - adds the missing methods discussed there)
- Fits the two-step migration strategy: `.0` → `.value()` → `.v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)