### PR TITLE
fix: add missing Pod/Zeroable impls for GrayA and Gray_v09 in as-bytes

### DIFF
--- a/src/as_bytes.rs
+++ b/src/as_bytes.rs
@@ -1,6 +1,9 @@
 use crate::{RGB, RGBA};
 use crate::alt::{Gray, GrayAlpha, BGR, BGRA};
 use crate::alt::{ARGB, ABGR};
+use crate::formats::gray_a::GrayA;
+#[cfg(feature = "unstable-experimental")]
+use crate::formats::gray::Gray_v09;
 use crate::ComponentBytes;
 
 #[cfg(feature = "as-bytes")]
@@ -114,4 +117,16 @@ impl<T: crate::Pod> ComponentBytes<T> for [Gray<T>] {}
 
 #[cfg(feature = "as-bytes")]
 impl<T: crate::Pod> ComponentBytes<T> for [GrayAlpha<T>] {}
+
+// GrayA and Gray_v09 use the sound single-type-parameter impls (T: Pod),
+// not the unsound two-parameter pattern used by the legacy types above.
+#[cfg(feature = "as-bytes")]
+unsafe impl<T: crate::Pod> crate::Pod for GrayA<T> {}
+#[cfg(feature = "as-bytes")]
+unsafe impl<T: crate::Zeroable> crate::Zeroable for GrayA<T> {}
+
+#[cfg(all(feature = "as-bytes", feature = "unstable-experimental"))]
+unsafe impl<T: crate::Pod> crate::Pod for Gray_v09<T> {}
+#[cfg(all(feature = "as-bytes", feature = "unstable-experimental"))]
+unsafe impl<T: crate::Zeroable> crate::Zeroable for Gray_v09<T> {}
 

--- a/tests/v08.rs
+++ b/tests/v08.rs
@@ -605,3 +605,25 @@ fn converts2() {
     assert_eq!(Bgra {r:1u8,g:2,b:3,a:4}, (3,2,1,4).into());
     assert_eq!(Bgr {r:1u8,g:2,b:3}, (3,2,1).into());
 }
+
+#[test]
+#[cfg(feature = "as-bytes")]
+fn graya_bytemuck_with_as_bytes() {
+    use rgb::GrayA;
+    let pixels: [GrayA<u8>; 2] = [GrayA { v: 1, a: 128 }, GrayA { v: 2, a: 255 }];
+    let bytes: &[u8] = rgb::bytemuck::cast_slice(&pixels);
+    assert_eq!(bytes, &[1, 128, 2, 255]);
+    let back: &[GrayA<u8>] = rgb::bytemuck::cast_slice(bytes);
+    assert_eq!(back, &pixels);
+}
+
+#[test]
+#[cfg(all(feature = "as-bytes", feature = "unstable-experimental"))]
+fn gray_v09_bytemuck_with_as_bytes() {
+    type Gray09<T> = rgb::Gray<T>;
+    let pixels = [Gray09 { v: 10u8 }, Gray09 { v: 20 }, Gray09 { v: 30 }];
+    let bytes: &[u8] = rgb::bytemuck::cast_slice(&pixels);
+    assert_eq!(bytes, &[10, 20, 30]);
+    let back: &[Gray09<u8>] = rgb::bytemuck::cast_slice(bytes);
+    assert_eq!(back, &pixels);
+}


### PR DESCRIPTION
## Summary
- The `as-bytes` feature path in `as_bytes.rs` implements `Pod`/`Zeroable` for all pixel types except `GrayA` and `Gray_v09`
- The `bytemuck` feature path (`bytemuck_impl.rs`) already covers these types, but since `as-bytes` and `bytemuck` are mutually exclusive, users of `as-bytes` cannot use `GrayA` with bytemuck
- This adds the missing impls, following the same patterns used for `GrayAlpha` and `Gray`

## Test plan
- [x] `cargo test --features as-bytes`
- [x] `cargo test --features bytemuck`
- [x] `cargo test --all-features`
- [x] `cargo test --no-default-features --features as-bytes`