### PR TITLE
Conditionally support TypeScript type definitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ num-traits = ["dep:num-traits"]
 defmt-03 = ["dep:defmt"]
 serde = ["dep:serde"]
 bytemuck = ["dep:bytemuck"]
+typescript-type-def = ["dep:typescript-type-def"]
 
 # Deprecated: it's always enabled anyway
 argb = []
@@ -45,6 +46,7 @@ serde = { version = "1.0.200", optional = true, default-features = false, featur
 bytemuck = { version = "1.17", optional = true, features = ["min_const_generics", "align_offset"] } # these give better code
 defmt = { version = "0.3.8", optional = true, default-features = false }
 num-traits = { version = "0.2.19", optional = true, default-features = false }
+typescript-type-def = { version = "0.5.13", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.100"

--- a/src/formats/abgr.rs
+++ b/src/formats/abgr.rs
@@ -1,6 +1,7 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// An `Alpha + Blue + Green + Red` pixel.
 ///

--- a/src/formats/argb.rs
+++ b/src/formats/argb.rs
@@ -1,6 +1,7 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// An `Alpha + Red + Green + Blue` pixel.
 ///

--- a/src/formats/bgr.rs
+++ b/src/formats/bgr.rs
@@ -1,6 +1,7 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Blue + Green + Red` pixel.
 ///

--- a/src/formats/bgra.rs
+++ b/src/formats/bgra.rs
@@ -1,6 +1,7 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Blue + Green + Red + Alpha` pixel.
 ///

--- a/src/formats/gray.rs
+++ b/src/formats/gray.rs
@@ -1,6 +1,7 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Grayscale` pixel
 ///
@@ -31,6 +32,7 @@ pub struct Gray_v08<T>(
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[doc(alias = "Luma")]
 #[doc(alias = "Mono")]

--- a/src/formats/gray_a.rs
+++ b/src/formats/gray_a.rs
@@ -1,6 +1,7 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Grayscale + Alpha` pixel (rgb crate v0.9)
 ///

--- a/src/formats/gray_a44.rs
+++ b/src/formats/gray_a44.rs
@@ -3,6 +3,7 @@ use core::fmt::Display;
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Grayscale + Alpha` 8-bit pixel with the first 4 bits used for the value
 /// component the last 4 bits used for the alpha component.

--- a/src/formats/gray_alpha.rs
+++ b/src/formats/gray_alpha.rs
@@ -5,6 +5,7 @@ use core::ops::DerefMut;
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A pixel for grayscale value + alpha components (rgb crate v0.8)
 ///

--- a/src/formats/grb.rs
+++ b/src/formats/grb.rs
@@ -1,6 +1,7 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Green + Red + Blue` pixel.
 ///

--- a/src/formats/rgb.rs
+++ b/src/formats/rgb.rs
@@ -1,6 +1,7 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Red + Green + Blue` pixel.
 ///

--- a/src/formats/rgba.rs
+++ b/src/formats/rgba.rs
@@ -1,6 +1,7 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Red + Green + Blue + Alpha` pixel.
 ///

--- a/src/formats/rgbw.rs
+++ b/src/formats/rgbw.rs
@@ -1,6 +1,7 @@
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "typescript-type-def", derive(typescript_type_def::TypeDef))]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 /// A `Red + Green + Blue + White` pixel.
 ///


### PR DESCRIPTION
This enables this crate's types to conditionally take part in TypeScript type definition generation via the `typescript_type_def::TypeDef`.

I am in no way affiliated with the `typescript-type-def` crate, this is just something I needed to implement in order to generate type definitions for my own crate. I will also understand if you'd rather not bloat your own crate with this.